### PR TITLE
Full License Rendering on Website

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: License
-permalink: /license/
+permalink: /license
 ---
 # Creative Commons Attribution-ShareAlike 4.0 International
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: License
+permalink: /license/
+---
 # Creative Commons Attribution-ShareAlike 4.0 International
 
 Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,16 @@
+# Theme setup (works for both upstream and forks)
+remote_theme: mindset-dojo/mindset-dojo.github.io@main
+
+plugins:
+  - jekyll-remote-theme
+
+# Optional custom permalink structure
 permalink: /:title
+
+# Custom site variable for external linking (you can reference this in layouts/templates as `site.connect_url`)
 connect_url: https://connect.mindset.dojo.center
 
+# Files excluded from GitHub Pages build
 exclude:
   - Gemfile
   - Gemfile.lock

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,7 +17,7 @@
 				<a href="/privacy-policy" {% if page.url=="/privacy-policy" %}aria-current="page" {% endif %} role="menuitem">Privacy Policy</a>
 			</li>
 			<li role="presentation">
-				<a href="https://raw.githubusercontent.com/mindset-dojo/mindset-dojo.github.io/refs/heads/main/LICENSE.md" role="menuitem">Open Source License</a>
+				<a href="/license/" {% if page.url=="/license/" %}aria-current="page" {% endif %} role="menuitem">Open Source License</a>
 			</li>
 		</ul>
 	</nav>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,7 +17,7 @@
 				<a href="/privacy-policy" {% if page.url=="/privacy-policy" %}aria-current="page" {% endif %} role="menuitem">Privacy Policy</a>
 			</li>
 			<li role="presentation">
-				<a href="/license/" {% if page.url=="/license/" %}aria-current="page" {% endif %} role="menuitem">Open Source License</a>
+				<a href="/license" {% if page.url=="/license" %}aria-current="page" {% endif %} role="menuitem">Open Source License</a>
 			</li>
 		</ul>
 	</nav>


### PR DESCRIPTION
Fixes #35. I tested this on my fork of the repository, and it rendered the page. Since my fork only renders HTML pages due to not having specialized GitHub Actions, I would note that you might want to test it yourself to see if the CSS and Javascript applies to the License page.