### PR TITLE
Full License Rendering Try 2

### DIFF
--- a/404.md
+++ b/404.md
@@ -8,5 +8,5 @@ css_id: error
 	<h1>You appear to be lost</h1>
 	<hr>
 	<p>Join the Mindset Dojo Community for Intentional Conversations, we can help!</p>
-	<a href="./community/" class="md-cta">Explore the community</a>
+	<a href="./community" class="md-cta">Explore the community</a>
 </main>

--- a/404.md
+++ b/404.md
@@ -1,12 +1,12 @@
 ---
 layout: default
 title: Page Not Found
-permalink: /404.html
+permalink: ./404.html
 css_id: error
 ---
 <main aria-label="Content">
 	<h1>You appear to be lost</h1>
 	<hr>
 	<p>Join the Mindset Dojo Community for Intentional Conversations, we can help!</p>
-	<a href="/community/" class="md-cta">Explore the community</a>
+	<a href="./community/" class="md-cta">Explore the community</a>
 </main>

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,8 @@
+---
+layout: default
+title: License
+permalink: /license
+---
 # Creative Commons Attribution-ShareAlike 4.0 International
 
 Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -17,7 +17,7 @@
 				<a href="/privacy-policy" {% if page.url=="/privacy-policy" %}aria-current="page" {% endif %} role="menuitem">Privacy Policy</a>
 			</li>
 			<li role="presentation">
-				<a href="https://raw.githubusercontent.com/mindset-dojo/mindset-dojo.github.io/refs/heads/main/LICENSE.md" role="menuitem">Open Source License</a>
+				<a href="/license" {% if page.url=="/license" %}aria-current="page" {% endif %} role="menuitem">Open Source License</a>
 			</li>
 		</ul>
 	</nav>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,10 +1,10 @@
 <footer>
 	<nav>
 		<ul role="menu">
-			<li role="presentation"><a href="/" {% if page.url=="/" %}aria-current="page" {% endif %} role="menuitem">HOME</a></li>
-			<li role="presentation"><a href="/impact" {% if page.url=="/impact" %}aria-current="page" {% endif %} role="menuitem">IMPACT</a></li>
-			<li role="presentation"><a href="/offerings" {% if page.url=="/offerings" %}aria-current="page" {% endif %} role="menuitem">OFFERINGS</a></li>
-			<li role="presentation"><a href="/community" {% if page.url=="/community" %}aria-current="page" {% endif %} role="menuitem">COMMUNITY</a></li>
+			<li role="presentation"><a href="./" {% if page.url=="./" %}aria-current="page" {% endif %} role="menuitem">HOME</a></li>
+			<li role="presentation"><a href="./impact" {% if page.url=="./impact" %}aria-current="page" {% endif %} role="menuitem">IMPACT</a></li>
+			<li role="presentation"><a href="./offerings" {% if page.url=="./offerings" %}aria-current="page" {% endif %} role="menuitem">OFFERINGS</a></li>
+			<li role="presentation"><a href="./community" {% if page.url=="./community" %}aria-current="page" {% endif %} role="menuitem">COMMUNITY</a></li>
 			<li role="presentation"><a href="{{site.connect_url}}" target="_blank" role="menuitem">CONTACT</a></li>
 		</ul>
 	</nav>
@@ -14,13 +14,13 @@
 				<p>© 2025 Mindset Dojo</p>
 			</li>
 			<li role="presentation">
-				<a href="/privacy-policy" {% if page.url=="/privacy-policy" %}aria-current="page" {% endif %} role="menuitem">Privacy Policy</a>
+				<a href="./privacy-policy" {% if page.url=="./privacy-policy" %}aria-current="page" {% endif %} role="menuitem">Privacy Policy</a>
 			</li>
 			<li role="presentation">
-				<a href="/license" {% if page.url=="/license" %}aria-current="page" {% endif %} role="menuitem">Open Source License</a>
+				<a href="./license" {% if page.url=="./license" %}aria-current="page" {% endif %} role="menuitem">Open Source License</a>
 			</li>
 		</ul>
 	</nav>
-	<img src="/assets/mindset-dojo-torii-gate.png" alt="Mindset Dojo Torii Gate Background Image" width="800" height="601" decoding="async" loading="lazy" sizes="(max-width: 800px) 100vw, 800px">
+	<img src="./assets/mindset-dojo-torii-gate.png" alt="Mindset Dojo Torii Gate Background Image" width="800" height="601" decoding="async" loading="lazy" sizes="(max-width: 800px) 100vw, 800px">
 </footer>
-<script src="/assets/js/md.js"></script>
+<script src="./assets/js/md.js"></script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,12 +6,12 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="robots" content="max-image-preview:large">
-	<link rel="preload" href="/assets/libs/google/fonts/afacad-v1-latin-700.woff2" crossorigin="anonymous" as="font" type="font/woff2">
-	<link rel="preload" href="/assets/libs/google/fonts/roboto-v47-latin-regular.woff2" crossorigin="anonymous" as="font" type="font/woff2">
-	<link rel="stylesheet" href="/assets/css/md.css" media="all">
+	<link rel="preload" href="./assets/libs/google/fonts/afacad-v1-latin-700.woff2" crossorigin="anonymous" as="font" type="font/woff2">
+	<link rel="preload" href="./assets/libs/google/fonts/roboto-v47-latin-regular.woff2" crossorigin="anonymous" as="font" type="font/woff2">
+	<link rel="stylesheet" href="./assets/css/md.css" media="all">
 	<link rel="canonical" href="{{ page.permalink }}">
-	<link rel="icon" href="/assets/favicon.png" sizes="32x32">
-	<link rel="icon" href="/assets/favicon.png" sizes="192x192">
-	<link rel="apple-touch-icon" href="/assets/favicon.png">
-	<meta name="msapplication-TileImage" content="/assets/favicon.png">
+	<link rel="icon" href="./assets/favicon.png" sizes="32x32">
+	<link rel="icon" href="./assets/favicon.png" sizes="192x192">
+	<link rel="apple-touch-icon" href="./assets/favicon.png">
+	<meta name="msapplication-TileImage" content="./assets/favicon.png">
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,5 @@
 <header>
-    <a href="/" aria-current="page">
+    <a href="./" aria-current="page">
         <img src="./assets/mindset-dojo-logo.png" alt="Mindset Dojo Logo" width="292" height="80" decoding="async" fetchpriority="high">
     </a>
     <nav id="Menu">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,10 +4,10 @@
     </a>
     <nav id="Menu">
         <ul role="menu">
-            <li class="md-hidden" role="presentation"><a href="/" {% if page.url=="/" %}aria-current="page" {% endif %} role="menuitem">HOME</a></li>
-            <li role="presentation"><a href="/impact" {% if page.url=="/impact" %}aria-current="page" {% endif %} role="menuitem">IMPACT</a></li>
-            <li role="presentation"><a href="/offerings" {% if page.url=="/offerings" %}aria-current="page" {% endif %} role="menuitem">OFFERINGS</a></li>
-            <li role="presentation"><a href="/community" {% if page.url=="/community" %}aria-current="page" {% endif %} role="menuitem">COMMUNITY</a></li>
+            <li class="md-hidden" role="presentation"><a href="./" {% if page.url=="./" %}aria-current="page" {% endif %} role="menuitem">HOME</a></li>
+            <li role="presentation"><a href="./impact" {% if page.url=="./impact" %}aria-current="page" {% endif %} role="menuitem">IMPACT</a></li>
+            <li role="presentation"><a href="./offerings" {% if page.url=="./offerings" %}aria-current="page" {% endif %} role="menuitem">OFFERINGS</a></li>
+            <li role="presentation"><a href="./community" {% if page.url=="./community" %}aria-current="page" {% endif %} role="menuitem">COMMUNITY</a></li>
             <li class="md-hidden" role="presentation"><a href="{{site.connect_url}}" target="_blank" role="menuitem">CONTACT</a></li>
         </ul>
         <button aria-label="Menu Toggle" aria-expanded="false" aria-controls="Menu" aria-haspopup="true">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,6 @@
 <header>
     <a href="/" aria-current="page">
-        <img src="/assets/mindset-dojo-logo.png" alt="Mindset Dojo Logo" width="292" height="80" decoding="async" fetchpriority="high">
+        <img src="./assets/mindset-dojo-logo.png" alt="Mindset Dojo Logo" width="292" height="80" decoding="async" fetchpriority="high">
     </a>
     <nav id="Menu">
         <ul role="menu">

--- a/assets/js/md.js
+++ b/assets/js/md.js
@@ -26,7 +26,7 @@ function initMD() {
         var playerElements = document.querySelectorAll('.md-youtube-player');
         for (var n = 0; n < playerElements.length; n++) {
             var videoId = playerElements[n].dataset.id;
-            var bgimgsrc = '/assets/video-previews/' + playerElements[n].dataset.preview;
+            var bgimgsrc = './assets/video-previews/' + playerElements[n].dataset.preview;
             var bgimgnosrc = '//i.ytimg.com/vi/ID/hqdefault.jpg'.replace('ID', videoId);
             if (playerElements[n].dataset.preview !== undefined && playerElements[n].dataset.preview !== '') {
                 playerElements[n].style.backgroundImage = 'url('+bgimgsrc+')';

--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ css_id: home
     <p>Unlike other programs that only focus on concepts, we emphasize the <strong>practical application</strong> of emotional intelligence in <strong>real time.</strong></p>
     <p>You’ll master emotions, lead with wisdom, and build authentic trust when it matters most. By honing these skills in high-pressure situations, you’ll foster <strong>better, more meaningful conversations</strong>, make <strong>wiser decisions</strong>, and create authentic connections that <strong>drive sustainable success</strong> both personally and professionally.</p>
     <div class="md-cta-group">
-        <a href="/impact">Explore Impact</a><a href="/offerings">View Offerings</a>
+        <a href="./impact">Explore Impact</a><a href="./offerings">View Offerings</a>
     </div>
     <h2>The Common Challenge, and Beyond</h2>
     <hr>


### PR DESCRIPTION
I managed to get the license page as well as the rest of the website to fully render on my fork by changing the absolute paths into relative paths as you suggested. Admittedly, the screenshot shows a bug where the heading menu blocks the user text, but I feel we can troubleshoot that.  
![Screenshot 2025-05-09 at 17-27-25 License](https://github.com/user-attachments/assets/82e5b202-3b69-408d-b94d-bbcb41d25db5)
