### PR TITLE
feat: Trusted Committer - Purple Belt condition

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ This helps ensure alignment between our inner work and our outward contributions
 
 Roles are voluntary and reviewed periodically to ensure mutual clarity and care. Cultivating a role is an opportunity for deeper training and responsibility—not a requirement for contribution or community engagement.
 
-### ✅ Trusted Committer (Blue Belt+)
+### ✅ Trusted Committer (Purple Belt+)
 - Demonstrates technical fluency and principled contribution
 - Understands the codebase and the ethos of the program
 - May merge PRs and curate discussions


### PR DESCRIPTION
As a Project Maintainer 
We need to ensure Trusted Committer are at Purple Belt or above
So that they are sufficiently vetted to flow with hard and unexpected paradoxical challenges.