### PR TITLE
feat(markdownlint): remove line length rule in markdownlint

### DIFF
--- a/.github/linters/.markdownlint.json
+++ b/.github/linters/.markdownlint.json
@@ -1,6 +1,6 @@
 {
   "default": true,
-  "MD013": { "line_length": 100, "severity": "error" },
+  "MD013": false,
   "MD041": { "level": "error" },
   "MD022": { "lines": 1, "level": "error" },
   "MD029": { "style": "ordered", "level": "error" },


### PR DESCRIPTION
To prevent headaches from people having to format Markdown to fit the Super-Linter Quality Gate when contributing posts in the future.

Link to Markdownlint rule being referenced: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md013---line-length