### PR TITLE
feat: Implement Leadership Designations

### DIFF
--- a/_data/authors/profiles/jeremy-mcmillan.yaml
+++ b/_data/authors/profiles/jeremy-mcmillan.yaml
@@ -3,6 +3,7 @@ name: Jeremy McMillan
 active: true
 join_date: 2021-01-01
 belt_level: -6
+belt_level_date: 2025-03-16
 leadership_designations: []
 linkedin: https://www.linkedin.com/in/jeremymcm
 links: [ ]

--- a/_data/authors/profiles/jeremy-mcmillan.yaml
+++ b/_data/authors/profiles/jeremy-mcmillan.yaml
@@ -3,9 +3,7 @@ name: Jeremy McMillan
 active: true
 join_date: 2021-01-01
 belt_level: -6
-leadership_designations:
-  - type: program
-    value: Wizard
+leadership_designations: []
 linkedin: https://www.linkedin.com/in/jeremymcm
 links: [ ]
 ...

--- a/_data/authors/profiles/jeremy-mcmillan.yaml
+++ b/_data/authors/profiles/jeremy-mcmillan.yaml
@@ -1,8 +1,9 @@
 ---
 name: Jeremy McMillan
 active: true
-belt_level: -6
 join_date: 2021-01-01
+belt_level: -6
+leadership_designations: []
 linkedin: https://www.linkedin.com/in/jeremymcm
 links: [ ]
 ...

--- a/_data/authors/profiles/jeremy-mcmillan.yaml
+++ b/_data/authors/profiles/jeremy-mcmillan.yaml
@@ -3,7 +3,9 @@ name: Jeremy McMillan
 active: true
 join_date: 2021-01-01
 belt_level: -6
-leadership_designations: []
+leadership_designations:
+  - type: program
+    value: Wizard
 linkedin: https://www.linkedin.com/in/jeremymcm
 links: [ ]
 ...

--- a/_data/authors/profiles/kyle-ingersoll.yaml
+++ b/_data/authors/profiles/kyle-ingersoll.yaml
@@ -3,6 +3,7 @@ name: Kyle Ingersoll
 active: true
 join_date: 2024-08-01
 belt_level: -2
+belt_level_date: 2025-08-30
 leadership_designations: []
 linkedin: https://www.linkedin.com/in/kyle-ingersoll
 links:

--- a/_data/authors/profiles/kyle-ingersoll.yaml
+++ b/_data/authors/profiles/kyle-ingersoll.yaml
@@ -1,8 +1,9 @@
 ---
 name: Kyle Ingersoll
 active: true
-belt_level: -2
 join_date: 2024-08-01
+belt_level: -2
+leadership_designations: []
 linkedin: https://www.linkedin.com/in/kyle-ingersoll
 links:
   - label: Resume

--- a/_data/authors/profiles/michael-basil.yaml
+++ b/_data/authors/profiles/michael-basil.yaml
@@ -3,6 +3,7 @@ name: Michael Basil
 active: true
 join_date: 2019-01-01
 belt_level: 1
+belt_level_date: 2025-01-12
 leadership_designations:
   - type: program
     value: Zensei

--- a/_data/authors/profiles/michael-basil.yaml
+++ b/_data/authors/profiles/michael-basil.yaml
@@ -1,8 +1,13 @@
 ---
 name: Michael Basil
 active: true
-belt_level: 1
 join_date: 2019-01-01
+belt_level: 1
+leadership_designations:
+  - type: program
+    value: Zensei
+  - type: project
+    value: Organizational Cultivator
 linkedin: https://www.linkedin.com/in/michael-100-basil
 links:
   - label: Inner-Game Lessons

--- a/_data/authors/profiles/patrick-burke.yaml
+++ b/_data/authors/profiles/patrick-burke.yaml
@@ -3,6 +3,7 @@ name: Patrick Burke
 active: true
 join_date: 2024-12-01
 belt_level: -5
+belt_level_date: 2025-05-04
 leadership_designations: []
 linkedin: https://www.linkedin.com/in/patrick-j-burke
 links: []

--- a/_data/authors/profiles/patrick-burke.yaml
+++ b/_data/authors/profiles/patrick-burke.yaml
@@ -1,8 +1,9 @@
 ---
 name: Patrick Burke
 active: true
-belt_level: -5
 join_date: 2024-12-01
+belt_level: -5
+leadership_designations: []
 linkedin: https://www.linkedin.com/in/patrick-j-burke
 links: []
 ...

--- a/_data/mission.yaml
+++ b/_data/mission.yaml
@@ -21,7 +21,7 @@ context:
     - "Because in high-stakes moments, you won’t have time to think — only respond."
     - "Because pressure doesn’t reveal your potential — it reveals your practice."
   mission_rally_suffix_label: ": Root Intention"
-  practice_bullets:
+  mission_statement_bridge:
     - "We practice live, in real conversations — where timing, tone, and tension are felt."
     - "We reflect between reps — using voice notes to recalibrate and deepen awareness."
     - "We progress with purpose — using a belt path that honors embodied thresholds."

--- a/_data/mission.yaml
+++ b/_data/mission.yaml
@@ -38,7 +38,7 @@ context:
       - "Thresholds turn circles into spirals — growth follows reciprocity."
   leadership_flow:
     label: "⛩️ Leadership in Flow"
-    limit: 2
+    limit: 8
   calls_to_action:
     - label: "Cross the Threshold"
       ref: program

--- a/_data/mission.yaml
+++ b/_data/mission.yaml
@@ -38,7 +38,7 @@ context:
       - "Thresholds turn circles into spirals — growth follows reciprocity."
   leadership_flow:
     label: "⛩️ Leadership in Flow"
-    limit: 16
+    limit: 2
   calls_to_action:
     - label: "Cross the Threshold"
       ref: program

--- a/_data/program.yaml
+++ b/_data/program.yaml
@@ -18,7 +18,7 @@ context:
   designations_aspects_label: Aspects
   leadership_flow:
     label: "⛩️ Leadership in Flow"
-    limit: 16
+    limit: 8
   calls_to_action:
     - label: Deepen the Training
       ref: connect

--- a/_data/program.yaml
+++ b/_data/program.yaml
@@ -6,7 +6,7 @@ context:
   mission_statement_bridge:
     - "We practice live, on the mat and in conversation."
     - "We log reflections and recalibrate between reps."
-    - "We advance belts by embodied thresholds."
+    - "We advance levels through embodied thresholds."
   principles_label: Principles
   forms_label: Forms
   levels_label: Levels

--- a/_data/program.yaml
+++ b/_data/program.yaml
@@ -3,6 +3,10 @@ rally: Fearless Leadership
 mantra: "Don't React. Center."
 context:
   mission_rally_suffix_label: ": Embodied Practice"
+  mission_statement_bridge:
+    - "We practice live, on the mat and in conversation."
+    - "We log reflections and recalibrate between reps."
+    - "We advance belts by embodied thresholds."
   principles_label: Principles
   forms_label: Forms
   levels_label: Levels

--- a/_data/project.yaml
+++ b/_data/project.yaml
@@ -33,13 +33,13 @@ designations:
     aspects:
       - label: Join Cultivator Circle regularly
       - label: Contribute to expertise in a mutually beneficial way
-      - label: Green Level+, sponsored by existing Cultivator
+      - label: Green Level+, vouched for by existing Cultivator(s)
   - label: Project Cultivator
     intention: Integrate program, community, and platform work
     aspects:
       - label: Lead Cultivator Circle sessions periodically
       - label: Servant leader for (Domain-Specific) Cultivators
-      - label: Black Level, sponsored by existing Cultivator
+      - label: Black Level, vouched for by existing Cultivator(s)
   - label: Organizational Cultivator
     intention: Embody integrative leadership across social, technical, and brand ecosystems
     aspects:

--- a/_data/project.yaml
+++ b/_data/project.yaml
@@ -27,7 +27,7 @@ context:
   designations_aspects_label: Aspects
   leadership_flow:
     label: "⛩️ Leadership in Flow"
-    limit: 16
+    limit: 8
   calls_to_action:
     - label: Inspect the Roots
       ref: repo

--- a/_data/project.yaml
+++ b/_data/project.yaml
@@ -2,6 +2,10 @@
 mantra: "Don't Hoard. Share."
 context:
   mission_rally_suffix_label: ": Living Structure"
+  mission_statement_bridge:
+    - "We move clarity into form — language, structure, and flow."
+    - "We sense friction in the knowledge field and adjust with care."
+    - "We welcome influence through open, visible practice."
   project_motivations_label: Project Motivations
   project_motivations:
     - "Our project is a shared practice of simplicity and coherence."
@@ -14,7 +18,7 @@ context:
     - "Invite courage through transparency and simplicity."
   contribution_invitations_label: Contribution Invitations
   contribution_invitations:
-    - "You notice a friction in the docs."
+    - "You sense where the system isn’t flowing."
     - "You refactor a phrase or function toward clarity."
     - "You offer a pattern that helps others move with ease."
   pullquote: "Ideation is fun, pull requests invite influence."

--- a/_includes/author.html
+++ b/_includes/author.html
@@ -1,11 +1,11 @@
 {%- comment -%}
-  _includes/member.html
+  _includes/author.html
   Expects:
-    include.member → profile object
+    include.author → profile object
     include.avatar → avatar object (type + b64)
 {%- endcomment -%}
 
-<section class="md-member-card">
+<section class="md-author-card">
 
   {%- comment -%} Render avatar from YAML base64 object {%- endcomment -%}
   {% assign mime = include.avatar.type | default: "image/jpeg" %}
@@ -13,14 +13,14 @@
 
   <img
     src="data:{{ mime }};base64,{{ b64 }}"
-    alt="{{ include.member.name }}"
+    alt="{{ include.author.name }}"
     width="100"
     height="100"
   />
 
-  <h2>{{ include.member.name }}</h2>
+  <h2>{{ include.author.name }}</h2>
 
-  {%- assign ld = include.member.leadership_designations -%}
+  {%- assign ld = include.author.leadership_designations -%}
   {%- if ld -%}
     {%- assign lines = "" | split: "" -%}
     {%- for item in ld -%}
@@ -34,16 +34,16 @@
     {%- endif -%}
   {%- endif -%}
 
-  {%- if include.member.linkedin or include.member.belt_level -%}
+  {%- if include.author.linkedin or include.author.belt_level -%}
     <div class="md-group">
-      {%- if include.member.linkedin -%}
-        <a href="{{ include.member.linkedin }}" target="_blank" aria-label="LinkedIn">
+      {%- if include.author.linkedin -%}
+        <a href="{{ include.author.linkedin }}" target="_blank" aria-label="LinkedIn">
           {% include icons/linkedin.svg class="md-icon-svg" %}
         </a>
       {%- endif -%}
 
-      {%- if include.member.belt_level -%}
-        {% assign belt_level = include.member.belt_level | plus: 0 %}
+      {%- if include.author.belt_level -%}
+        {% assign belt_level = include.author.belt_level | plus: 0 %}
         {% assign level = site.data.program.levels | where: "level", belt_level | first %}
         {% include icons/belt.svg
            class="md-belt-svg"
@@ -53,9 +53,9 @@
     </div>
   {%- endif -%}
 
-  {%- if include.member.links -%}
+  {%- if include.author.links -%}
     <ul>
-      {% for link in include.member.links %}
+      {% for link in include.author.links %}
         <li><a href="{{ link.url }}">{{ link.label }}</a></li>
       {% endfor %}
     </ul>

--- a/_includes/authors-grid.html
+++ b/_includes/authors-grid.html
@@ -35,10 +35,10 @@ Usage:
   {%- comment -%} 1) Build sortable list of active authors {%- endcomment -%}
   {% for pair in profiles %}
     {% assign key = pair[0] %}
-    {% assign member = pair[1] %}
-    {% if member.active %}
-      {%- assign neg_belt = member.belt_level | times: -1 | plus: 1000 | prepend: "0000" | slice: -4, 4 -%}
-      {% capture entry %}{{ neg_belt }}|{{ member.join_date }}|{{ key }}{% endcapture %}
+    {% assign author = pair[1] %}
+    {% if author.active %}
+      {%- assign neg_belt = author.belt_level | times: -1 | plus: 1000 | prepend: "0000" | slice: -4, 4 -%}
+      {% capture entry %}{{ neg_belt }}|{{ author.join_date }}|{{ key }}{% endcapture %}
       {% assign entries = entries | push: entry %}
     {% endif %}
   {% endfor %}
@@ -50,8 +50,8 @@ Usage:
   {% for entry in sorted_entries %}
     {% assign parts  = entry | split: "|" %}
     {% assign key    = parts[2] %}
-    {% assign member = profiles[key] %}
+    {% assign author = profiles[key] %}
     {% assign avatar = avatars[key] %}
-    {% include member.html member=member avatar=avatar %}
+    {% include author.html author=author avatar=avatar %}
   {% endfor %}
 </div>

--- a/_includes/authors-grid.html
+++ b/_includes/authors-grid.html
@@ -6,8 +6,10 @@ Purpose:
 
 Parameters:
   - leadership_flow (optional): map with at least `label`
-  - profiles? (optional): override data source
-  - avatars?  (optional): override data source
+  - profiles?  (optional): override data source
+  - avatars?   (optional): override data source
+  - designation_type? (optional): filter authors who have a non-empty
+      leadership designation of this type (e.g., "program", "project")
 
 Data Source (defaults):
   site.data.authors.profiles
@@ -16,6 +18,7 @@ Data Source (defaults):
 Usage:
   {% include authors-grid.html %}  <!-- grid only -->
   {% include authors-grid.html leadership_flow=context.leadership_flow %}
+  {% include authors-grid.html designation_type="project" %}
 {%- endcomment -%}
 
 {%- assign profiles = include.profiles | default: site.data.authors.profiles -%}
@@ -32,11 +35,30 @@ Usage:
 {%- endif -%}
 
 <div class="md-authors">
-  {%- comment -%} 1) Build sortable list of active authors {%- endcomment -%}
+  {%- comment -%} 1) Build sortable list of active (optionally filtered) authors {%- endcomment -%}
   {% for pair in profiles %}
     {% assign key = pair[0] %}
     {% assign author = pair[1] %}
-    {% if author.active %}
+
+    {%- assign show_author = author.active -%}
+
+    {%- if show_author and include.designation_type -%}
+      {%- assign dt = include.designation_type | downcase | strip -%}
+      {%- assign show_author = false -%}
+      {%- assign ld = author.leadership_designations -%}
+
+      {%- if ld and ld.size > 0 -%}
+        {%- for item in ld -%}
+          {%- assign t = item.type  | downcase | strip -%}
+          {%- assign v = item.value | default: item.key | to_s | strip -%}
+          {%- if t == dt and v != "" and v != "null" -%}
+            {%- assign show_author = true -%}
+          {%- endif -%}
+        {%- endfor -%}
+      {%- endif -%}
+    {%- endif -%}
+
+    {% if show_author %}
       {%- assign neg_belt = author.belt_level | times: -1 | plus: 1000 | prepend: "0000" | slice: -4, 4 -%}
       {% capture entry %}{{ neg_belt }}|{{ author.join_date }}|{{ key }}{% endcapture %}
       {% assign entries = entries | push: entry %}

--- a/_includes/authors-grid.html
+++ b/_includes/authors-grid.html
@@ -2,10 +2,10 @@
 authors-grid.html
 ──────────────────
 Purpose:
-  Render a grid of active authors and potentially an introduction title
+  Render a grid of active authors and (optionally) a wrapper/heading.
 
 Parameters:
-  - leadership_flow (optional): map with at least `label`
+  - leadership_flow (optional): map with at least `label`; may include `limit`
   - profiles?  (optional): override data source
   - avatars?   (optional): override data source
   - designation_type? (optional): filter authors who have a non-empty
@@ -15,10 +15,12 @@ Data Source (defaults):
   site.data.authors.profiles
   site.data.authors.avatars
 
-Usage:
-  {% include authors-grid.html %}  <!-- grid only -->
-  {% include authors-grid.html leadership_flow=context.leadership_flow %}
-  {% include authors-grid.html designation_type="project" %}
+Sort:
+  1) belt_level DESC (higher first)
+  2) belt_level_date ASC (earlier first; falls back to join_date, then to "9999-12-31")
+
+Limit:
+  If leadership_flow.limit is set, only render up to that many authors.
 {%- endcomment -%}
 
 {%- assign profiles = include.profiles | default: site.data.authors.profiles -%}
@@ -46,7 +48,6 @@ Usage:
       {%- assign dt = include.designation_type | downcase | strip -%}
       {%- assign show_author = false -%}
       {%- assign ld = author.leadership_designations -%}
-
       {%- if ld and ld.size > 0 -%}
         {%- for item in ld -%}
           {%- assign t = item.type  | downcase | strip -%}
@@ -59,17 +60,31 @@ Usage:
     {%- endif -%}
 
     {% if show_author %}
+      {%- comment -%}
+        belt_level DESC → negate, pad, and sort ASC
+        date ASC → use belt_level_date, fall back to join_date, else far future to push to end
+      {%- endcomment -%}
       {%- assign neg_belt = author.belt_level | times: -1 | plus: 1000 | prepend: "0000" | slice: -4, 4 -%}
-      {% capture entry %}{{ neg_belt }}|{{ author.join_date }}|{{ key }}{% endcapture %}
+      {%- assign bld = author.belt_level_date | default: author.join_date | default: "9999-12-31" -%}
+      {% capture entry %}{{ neg_belt }}|{{ bld }}|{{ key }}{% endcapture %}
       {% assign entries = entries | push: entry %}
     {% endif %}
   {% endfor %}
 
-  {%- comment -%} 2) Sort by belt_level DESC, then join_date ASC {%- endcomment -%}
+  {%- comment -%} 2) Sort by belt_level DESC (via neg_belt), then belt_level_date ASC {%- endcomment -%}
   {% assign sorted_entries = entries | sort %}
 
-  {%- comment -%} 3) Render each profile card {%- endcomment -%}
-  {% for entry in sorted_entries %}
+  {%- comment -%} 3) Respect optional limit from leadership_flow.limit {%- endcomment -%}
+  {%- assign render_entries = sorted_entries -%}
+  {%- if include.leadership_flow and include.leadership_flow.limit -%}
+    {%- assign lim = include.leadership_flow.limit | plus: 0 -%}
+    {%- if lim > 0 and render_entries.size > lim -%}
+      {%- assign render_entries = render_entries | slice: 0, lim -%}
+    {%- endif -%}
+  {%- endif -%}
+
+  {%- comment -%} 4) Render each profile card {%- endcomment -%}
+  {% for entry in render_entries %}
     {% assign parts  = entry | split: "|" %}
     {% assign key    = parts[2] %}
     {% assign author = profiles[key] %}

--- a/_includes/member.html
+++ b/_includes/member.html
@@ -20,6 +20,20 @@
 
   <h2>{{ include.member.name }}</h2>
 
+  {%- assign ld = include.member.leadership_designations -%}
+  {%- if ld -%}
+    {%- assign lines = "" | split: "" -%}
+    {%- for item in ld -%}
+      {%- assign v = item.value | to_s | strip -%}
+      {%- if v != "" and v != "null" -%}
+        {%- assign lines = lines | push: v -%}
+      {%- endif -%}
+    {%- endfor -%}
+    {%- if lines.size > 0 -%}
+  <p>{{ lines | join: "<br>" }}</p>
+    {%- endif -%}
+  {%- endif -%}
+
   {%- if include.member.linkedin or include.member.belt_level -%}
     <div class="md-group">
       {%- if include.member.linkedin -%}

--- a/_includes/mission-core.html
+++ b/_includes/mission-core.html
@@ -1,0 +1,22 @@
+{%- comment -%}
+  mission-core.html
+  Purpose: shared “mission + bridge” block to avoid duplication (JSCPD).
+  Expects:
+    - mission: site.data.mission (or equivalent object with .rally and .statement)
+    - context: object that has .mission_rally_suffix_label and .mission_statement_bridge
+  Visual/Text: identical to prior inline section.
+{%- endcomment -%}
+
+<section class="md-flow">
+  <h2>{{ mission.rally }}{{ context.mission_rally_suffix_label }}</h2>
+  <br>
+  {% for item in mission.statement %}
+  <p>{{ item }}</p>
+  {% endfor %}
+
+  <hr/>
+
+  {% for item in context.mission_statement_bridge %}
+  <p>{{ item }}</p>
+  {% endfor %}
+</section>

--- a/assets/css/md.css
+++ b/assets/css/md.css
@@ -671,7 +671,7 @@ footer img {
 
 .md-authors section p {
     text-align: center;
-    margin: 4px 0px 4px 0px;
+    margin: 0px 0px 12px 0px;
 }
 
 .md-authors {

--- a/assets/css/md.css
+++ b/assets/css/md.css
@@ -669,6 +669,11 @@ footer img {
     padding: 0;
 }
 
+.md-authors section p {
+    text-align: center;
+    margin: 4px 0px 4px 0px;
+}
+
 .md-authors {
     display: grid;
     align-items: initial;

--- a/assets/css/md.css
+++ b/assets/css/md.css
@@ -669,9 +669,9 @@ footer img {
     padding: 0;
 }
 
-.md-authors section p {
+.md-authors section.md-author-card > p {
     text-align: center;
-    margin: 0px 0px 12px 0px;
+    margin: 0px 0px 12px;
 }
 
 .md-authors {

--- a/assets/css/md.css
+++ b/assets/css/md.css
@@ -659,6 +659,61 @@ footer img {
 }
 
 /* =========================================
+   GLOBAL FLOW SECTION PATTERN (opt-in)
+   Apply to any <section class="md-flow"> inside <main>
+   ========================================= */
+
+main > section.md-flow {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 2rem 1rem;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+main > section.md-flow > h2,
+main > section.md-flow > p {
+  max-width: 700px;
+  text-align: center;
+  margin: 0 auto 1rem;
+  padding: 0 1rem;
+}
+
+main > section.md-flow > ul {
+  max-width: 700px;
+  margin: 0 auto 1.5rem;
+  padding-left: 0;
+  text-align: center;
+}
+
+main > section.md-flow > ul li {
+  text-align: left;
+}
+
+main > section.md-flow > blockquote {
+  max-width: 700px;
+  margin: 20px auto 40px;
+  padding-left: 32px;
+  border-left: 8px solid var(--brand-color-primary);
+}
+
+@media (width <= 600px) {
+  main > section.md-flow {
+    padding: 1rem 0.5rem;
+  }
+
+  main > section.md-flow > ul {
+    max-width: 100%;
+    padding: 0 1rem;
+  }
+
+  main > section.md-flow > ul li {
+    font-size: var(--text-s);
+  }
+}
+
+/* =========================================
    AUTHORS styling
    ========================================= */
 
@@ -669,7 +724,7 @@ footer img {
     padding: 0;
 }
 
-.md-authors :where(section.md-author-card) > p {
+.md-authors section.md-author-card > p {
     text-align: center;
     margin: 0 0 12px;
 }
@@ -730,61 +785,6 @@ footer img {
     color: var(--light-color-primary);
     margin-bottom: 12px;
     padding: 0 12px;
-}
-
-/* =========================================
-   GLOBAL FLOW SECTION PATTERN (opt-in)
-   Apply to any <section class="md-flow"> inside <main>
-   ========================================= */
-
-main > section.md-flow {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 2rem 1rem;
-  max-width: 800px;
-  margin: 0 auto;
-}
-
-main > section.md-flow > h2,
-main > section.md-flow > p {
-  max-width: 700px;
-  text-align: center;
-  margin: 0 auto 1rem;
-  padding: 0 1rem;
-}
-
-main > section.md-flow > ul {
-  max-width: 700px;
-  margin: 0 auto 1.5rem;
-  padding-left: 0;
-  text-align: center;
-}
-
-main > section.md-flow > ul li {
-  text-align: left;
-}
-
-main > section.md-flow > blockquote {
-  max-width: 700px;
-  margin: 20px auto 40px;
-  padding-left: 32px;
-  border-left: 8px solid var(--brand-color-primary);
-}
-
-@media (width <= 600px) {
-  main > section.md-flow {
-    padding: 1rem 0.5rem;
-  }
-
-  main > section.md-flow > ul {
-    max-width: 100%;
-    padding: 0 1rem;
-  }
-
-  main > section.md-flow > ul li {
-    font-size: var(--text-s);
-  }
 }
 
 /* [PAGE SPECIFIC] */

--- a/assets/css/md.css
+++ b/assets/css/md.css
@@ -669,9 +669,9 @@ footer img {
     padding: 0;
 }
 
-.md-authors section.md-author-card > p {
+.md-authors :where(section.md-author-card) > p {
     text-align: center;
-    margin: 0px 0px 12px;
+    margin: 0 0 12px;
 }
 
 .md-authors {

--- a/assets/css/md.css
+++ b/assets/css/md.css
@@ -759,7 +759,7 @@ main > section.md-flow > blockquote {
     overflow: hidden;
 }
 
-.md-authors section h2 {
+.md-authors section.md-author-card > h2 {
     font-size: var(--h4);
 }
 
@@ -779,12 +779,6 @@ main > section.md-flow > blockquote {
     column-gap: 16px;
     margin-bottom: 12px;
     font-size: 0;
-}
-
-.md-authors section blockquote {
-    color: var(--light-color-primary);
-    margin-bottom: 12px;
-    padding: 0 12px;
 }
 
 /* [PAGE SPECIFIC] */

--- a/mission.md
+++ b/mission.md
@@ -38,7 +38,7 @@ css_id: home
 
   <hr/>
 
-  {% for item in context.practice_bullets %}
+  {% for item in context.mission_statement_bridge %}
   <p>{{ item }}</p>
   {% endfor %}
 </section>

--- a/mission.md
+++ b/mission.md
@@ -29,19 +29,7 @@ css_id: home
   {% endfor %}
 </section>
 
-<section class="md-flow">
-  <h2>{{ mission.rally }}{{ context.mission_rally_suffix_label }}</h2>
-  <br>
-  {% for item in mission.statement %}
-  <p>{{ item }}</p>
-  {% endfor %}
-
-  <hr/>
-
-  {% for item in context.mission_statement_bridge %}
-  <p>{{ item }}</p>
-  {% endfor %}
-</section>
+{% include mission-core.html mission=mission context=context %}
 
 <section class="md-flow">
   <h2>{{ context.energy.label }}</h2>

--- a/program.md
+++ b/program.md
@@ -69,6 +69,6 @@ css_id: program
 
 {% include designations.html designations=program.designations context=context %}
 
-{% include authors-grid.html leadership_flow=context.leadership_flow designation_type="program" %}
+{% include authors-grid.html leadership_flow=context.leadership_flow %}
 
 {% include cta-group.html ctas=context.calls_to_action %}

--- a/program.md
+++ b/program.md
@@ -11,19 +11,7 @@ css_id: program
 {% assign program = site.data.program %}
 {% assign context = program.context %}
 
-<section class="md-flow">
-  <h2>{{ mission.rally }}{{ context.mission_rally_suffix_label }}</h2>
-  <br>
-  {% for item in mission.statement %}
-  <p>{{ item }}</p>
-  {% endfor %}
-
-  <hr/>
-
-  {% for item in context.mission_statement_bridge %}
-  <p>{{ item }}</p>
-  {% endfor %}
-</section>
+{% include mission-core.html mission=mission context=context %}
 
 <section class="md-flow">
   <h2>{{ context.principles_label }}</h2>

--- a/program.md
+++ b/program.md
@@ -17,6 +17,12 @@ css_id: program
   {% for item in mission.statement %}
   <p>{{ item }}</p>
   {% endfor %}
+
+  <hr/>
+
+  {% for item in context.mission_statement_bridge %}
+  <p>{{ item }}</p>
+  {% endfor %}
 </section>
 
 <section class="md-flow">

--- a/program.md
+++ b/program.md
@@ -69,6 +69,6 @@ css_id: program
 
 {% include designations.html designations=program.designations context=context %}
 
-{% include authors-grid.html leadership_flow=context.leadership_flow %}
+{% include authors-grid.html leadership_flow=context.leadership_flow designation_type="program" %}
 
 {% include cta-group.html ctas=context.calls_to_action %}

--- a/project.md
+++ b/project.md
@@ -51,6 +51,6 @@ css_id: project
 
 {% include designations.html designations=project.designations context=context %}
 
-{% include authors-grid.html leadership_flow=context.leadership_flow %}
+{% include authors-grid.html leadership_flow=context.leadership_flow designation_type="project" %}
 
 {% include cta-group.html ctas=context.calls_to_action %}

--- a/project.md
+++ b/project.md
@@ -16,6 +16,12 @@ css_id: project
   {% for item in mission.statement %}
   <p>{{ item }}</p>
   {% endfor %}
+
+  <hr/>
+
+  {% for item in context.mission_statement_bridge %}
+  <p>{{ item }}</p>
+  {% endfor %}
 </section>
 
 <section class="md-flow">

--- a/project.md
+++ b/project.md
@@ -11,18 +11,7 @@ css_id: project
 {% assign project = site.data.project %}
 {% assign context = project.context %}
 
-<section class="md-flow">
-  <h2>{{ mission.rally }}{{ context.mission_rally_suffix_label }}</h2>
-  {% for item in mission.statement %}
-  <p>{{ item }}</p>
-  {% endfor %}
-
-  <hr/>
-
-  {% for item in context.mission_statement_bridge %}
-  <p>{{ item }}</p>
-  {% endfor %}
-</section>
+{% include mission-core.html mission=mission context=context %}
 
 <section class="md-flow">
   <h2>{{ context.project_motivations_label }} </h2>


### PR DESCRIPTION
**Changes:**

* Implement Leadership designations:
  * YAML
  * Card display on site
  * Authors-Grid
* Allow filtering of Author-Grid for specific leadership designation types
  * Filtering on Project page
  * Not filtering anywhere else
* Implemented limit functionality on how many cards will be rendered on a given grid
* Implemented belt_level_date functionality
* Implemented mission statement bridge language 

**Benefits:**

* Mission is further clarified
* Community has clear recognition of leadership energy investment
* Individuals able to cultivate high trust networking through people they meet and co-author with

 **Next:**

* @Computer8543 to review and hopefully approve! 🙏
* @Computer8543 to make separate pull request to claim his appropriate leadership designations
* We will reconcile how to consider Insight posting activity in how cards display over time (how to do that will become more obvious later and does not need to be unpacked and planned now - trust the emergence!)

Live: https://mindset.dojo.center