### PR TITLE
feat: Clarify Project Cultivator qualification

### DIFF
--- a/_data/project.yaml
+++ b/_data/project.yaml
@@ -50,7 +50,7 @@ sections:
           aspects:
             - label: "Lead Cultivator Circle sessions regularly"
             - label: "Cultivate project culture and brand coherence"
-            - label: "Black Level, Zen Leadership Instructor intention"
+            - label: "Black Level, vouched for by existing Cultivator(s)"
   - type: authors
     data:
       leadership_flow:


### PR DESCRIPTION
Change:

Remove qualifier of Zen Leadership Instructor intention in favor of vouch

Rationale:

This shift in bias will allow for a more natural and wider set of potential perspectives to consider for integration.  Additionally, it signals relational trust and program integrity are what we value and will rely on.

Unchanged:

Program leadership at the Zensei level will remain Zen Leadership Instructor as an additional qualifier to Black Level as that is in the spirit and depth of the program.