### PR TITLE
Introduce CSS to center text for Insight Stream and Insight Articles

### DIFF
--- a/assets/css/03-layout.css
+++ b/assets/css/03-layout.css
@@ -4,7 +4,7 @@
 
   /* Primary content container */
   main {
-    max-width: 800px;
+    max-width: 700px;
     margin: 20px auto 60px;
     flex-flow: column;
     display: flex;
@@ -89,7 +89,7 @@
     flex-direction: column;
     align-items: center;
     padding: 2rem 1rem;
-    max-width: 800px;
+    max-width: 700px;
     margin: 0 auto;
   }
 

--- a/assets/css/04-components-3-content.css
+++ b/assets/css/04-components-3-content.css
@@ -88,7 +88,7 @@
   }
 
   /* For lists inside .post-body: */
-  .post-body ul {
+  :where(.post-body ul) {
     display: inline-block;       
     text-align: left;            
     list-style-position: inside; 

--- a/assets/css/04-components-3-content.css
+++ b/assets/css/04-components-3-content.css
@@ -104,15 +104,14 @@
   /* Post body context variants (moved from UI) */
   .post-body .md-grid-2 blockquote,
   .post-body .md-grid-3 blockquote {
-    position: relative; /* so the ::before is positioned relative to this block */
-    display: inline-block; /* shrink-to-fit width of content */
-    margin: 1.5em auto; /* center it horizontally */
-    padding: 1em 1.5em; /* space inside so text doesn’t touch edges */
+    position: relative;
+    display: inline-block;
+    margin: 1.5em auto;
+    padding: 1em 1.5em;
     background-color: var(--dark-color-secondary);
     border-radius: 24px;
     text-align: center;
-    /* maybe set a max-width so it doesn’t stretch too wide */
-    max-width: 80%; /* or whatever works */
+    max-width: 80%;
   }
 
   .post-body .md-grid-2 blockquote::before,
@@ -122,8 +121,8 @@
     top: 0;
     bottom: 0;
     left: 0;
-    width: 6px; /* thickness of your stripe */
-    background-color: var(--brand-color); /* yellow stripe color */
+    width: 6px;
+    background-color: var(--brand-color);
     border-top-left-radius: 24px;
     border-bottom-left-radius: 24px;
   }

--- a/assets/css/04-components-3-content.css
+++ b/assets/css/04-components-3-content.css
@@ -104,17 +104,35 @@
   /* Post body context variants (moved from UI) */
   .post-body .md-grid-2 blockquote,
   .post-body .md-grid-3 blockquote {
-    align-self: center;
-    text-align: center;
-    display: inline-flex;
-    border-radius: 24px;
+    position: relative; /* so the ::before is positioned relative to this block */
+    display: inline-block; /* shrink-to-fit width of content */
+    margin: 1.5em auto; /* center it horizontally */
+    padding: 1em 1.5em; /* space inside so text doesn’t touch edges */
     background-color: var(--dark-color-secondary);
-    padding: 32px;
-    margin: 0;
+    border-radius: 24px;
+    text-align: center;
+    /* maybe set a max-width so it doesn’t stretch too wide */
+    max-width: 80%; /* or whatever works */
   }
 
+  .post-body .md-grid-2 blockquote::before,
+  .post-body .md-grid-3 blockquote::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 6px; /* thickness of your stripe */
+    background-color: var(--brand-color); /* yellow stripe color */
+    border-top-left-radius: 24px;
+    border-bottom-left-radius: 24px;
+  }
+
+  /* Ensuring paragraphs inside the blockquote behave nicely */
   .post-body .md-grid-2 blockquote p,
   .post-body .md-grid-3 blockquote p {
+    margin: 0.5em 0;
     font-size: var(--text-s);
   }
+
 }

--- a/assets/css/04-components-3-content.css
+++ b/assets/css/04-components-3-content.css
@@ -74,6 +74,7 @@
      ======================= */
 
   .post-article {
+    max-width: 700px;
     background: transparent;
   }
 

--- a/assets/css/04-components-3-content.css
+++ b/assets/css/04-components-3-content.css
@@ -106,7 +106,7 @@
   .post-body .md-grid-3 blockquote {
     align-self: center;
     text-align: center;
-    display: inline-block;
+    display: inline-flex;
     border-radius: 24px;
     background-color: var(--dark-color-secondary);
     padding: 32px;

--- a/assets/css/04-components-3-content.css
+++ b/assets/css/04-components-3-content.css
@@ -75,8 +75,6 @@
 
   .post-article {
     background: transparent;
-    align-self: center;
-    text-align: center;
   }
 
   .post-header {
@@ -87,6 +85,13 @@
 
   .post-body {
     background: transparent;
+    align-self: center;
+    text-align: center;
+  }
+
+  .post-meta {
+    align-self: center;
+    text-align: center;
   }
 
   /* Post body context variants (moved from UI) */

--- a/assets/css/04-components-3-content.css
+++ b/assets/css/04-components-3-content.css
@@ -104,6 +104,7 @@
   /* Post body context variants (moved from UI) */
   .post-body .md-grid-2 blockquote,
   .post-body .md-grid-3 blockquote {
+    align-self: center;
     display: inline-block;
     border-radius: 24px;
     background-color: var(--dark-color-secondary);

--- a/assets/css/04-components-3-content.css
+++ b/assets/css/04-components-3-content.css
@@ -104,6 +104,7 @@
   /* Post body context variants (moved from UI) */
   .post-body .md-grid-2 blockquote,
   .post-body .md-grid-3 blockquote {
+    display: inline-block;
     border-radius: 24px;
     background-color: var(--dark-color-secondary);
     padding: 32px;

--- a/assets/css/04-components-3-content.css
+++ b/assets/css/04-components-3-content.css
@@ -75,6 +75,8 @@
 
   .post-article {
     background: transparent;
+    align-self: center;
+    text-align: center;
   }
 
   .post-header {

--- a/assets/css/04-components-3-content.css
+++ b/assets/css/04-components-3-content.css
@@ -84,9 +84,16 @@
   }
 
   .post-body {
-    background: transparent;
-    align-self: center;
-    text-align: center;
+    text-align: center;    
+  }
+
+  /* For lists inside .post-body: */
+  .post-body ul {
+    display: inline-block;       
+    text-align: left;            
+    list-style-position: inside; 
+    margin: 0;
+    padding: 0;
   }
 
   .post-meta {

--- a/assets/css/04-components-3-content.css
+++ b/assets/css/04-components-3-content.css
@@ -105,6 +105,7 @@
   .post-body .md-grid-2 blockquote,
   .post-body .md-grid-3 blockquote {
     align-self: center;
+    text-align: center;
     display: inline-block;
     border-radius: 24px;
     background-color: var(--dark-color-secondary);

--- a/assets/css/05-pages.css
+++ b/assets/css/05-pages.css
@@ -11,7 +11,7 @@
   }
 
   /* [INSIGHT] */
-  #insight  {
+  #insight.article  {
     max-width: 700px;
     align-self: center;
     text-align: center; 

--- a/assets/css/05-pages.css
+++ b/assets/css/05-pages.css
@@ -12,8 +12,6 @@
 
   /* [INSIGHT] */
   #insight.article  {
-    max-width: 700px;
-    align-self: center;
     text-align: center; 
   }
 }

--- a/assets/css/05-pages.css
+++ b/assets/css/05-pages.css
@@ -9,4 +9,9 @@
     text-align: center;
     margin-bottom: 20px;
   }
+
+  /* [INSIGHT] */
+  #insight .insights-stream {
+    text-align: center;
+  }
 }

--- a/assets/css/05-pages.css
+++ b/assets/css/05-pages.css
@@ -11,7 +11,9 @@
   }
 
   /* [INSIGHT] */
-  #insight .insights-stream {
+  #insight .insights-stream h3.title,
+  #insight .insights-stream p.meta,
+  #insight .insights-stream div.excerpt {
     text-align: center;
   }
 }

--- a/assets/css/05-pages.css
+++ b/assets/css/05-pages.css
@@ -12,6 +12,7 @@
 
   /* [INSIGHT] */
   #insight  {
+    max-width: 700px;
     align-self: center;
     text-align: center; 
   }

--- a/assets/css/05-pages.css
+++ b/assets/css/05-pages.css
@@ -11,9 +11,5 @@
   }
 
   /* [INSIGHT] */
-  #insight .insights-stream h3.title,
-  #insight .insights-stream p.meta,
-  #insight .insights-stream div.excerpt {
-    text-align: center;
-  }
+  #insight  { text-align: center; }
 }

--- a/assets/css/05-pages.css
+++ b/assets/css/05-pages.css
@@ -11,7 +11,7 @@
   }
 
   /* [INSIGHT] */
-  #insight.article  {
+  #insight article  {
     text-align: center; 
   }
 }

--- a/assets/css/05-pages.css
+++ b/assets/css/05-pages.css
@@ -11,5 +11,8 @@
   }
 
   /* [INSIGHT] */
-  #insight  { text-align: center; }
+  #insight  {
+    align-self: center;
+    text-align: center; 
+  }
 }

--- a/assets/css/05-pages.css
+++ b/assets/css/05-pages.css
@@ -11,7 +11,7 @@
   }
 
   /* [INSIGHT] */
-  #insight article  {
+  #insight  {
     text-align: center; 
   }
 }

--- a/insight.md
+++ b/insight.md
@@ -47,7 +47,7 @@ permalink: /insight/
     {%- endcomment -%}
     {% assign post_url = '/insight/' | append: post_slug | append: '/' | relative_url %}
 
-      <h3><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
+      <h3 class="title"><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
 
       {% assign author_slugs = post.authors %}
       {% assign authors_names = "" | split: "," %}

--- a/insight.md
+++ b/insight.md
@@ -47,8 +47,6 @@ permalink: /insight/
     {%- endcomment -%}
     {% assign post_url = '/insight/' | append: post_slug | append: '/' | relative_url %}
 
-      <h3 class="title"><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
-
       {% assign author_slugs = post.authors %}
       {% assign authors_names = "" | split: "," %}
 
@@ -80,17 +78,20 @@ permalink: /insight/
           {% assign author_count = author_count | plus: 1 %}
         {% endfor %}
       {% endif %}
-
-      <p class="meta">
-        By {{ author_name_string | default: site.author }} — {{ post.date | date: "%b %-d, %Y" }}
-      </p>
       
       {% assign post_slug = post.slug | default: post.title | slugify %}
       {% assign post_date = post.date | default: "2025-01-01" | date: "%Y-%m-%d" | slugify %}
-      
-      <div class="excerpt">
-        {{ post.excerpt | default: post.content | strip_html | truncate: 220 }}
-      </div>
-    <hr>
+
+      <article>
+        <h3 class="title"><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h3>
+        <p class="meta">
+          By {{ author_name_string | default: site.author }} — {{ post.date | date: "%b %-d, %Y" }}
+        </p>
+        <p class="excerpt">
+          {{ post.excerpt | default: post.content | strip_html | truncate: 220 }}
+        </p>
+        <hr>
+      </article>
+
   {% endfor %}
 </section>


### PR DESCRIPTION
**Benefits:**

- **Mission:** Spreads Fearless Leadership by increasing resonance
- **Community:** Looks more professional, thus attracting more values-aligned people
- **Individual:** Have better reading experience

**Changes:**

- Refactored insight.md to put the rendered text in an <article> tag for easier CSS styling
- Added centering text CSS code for the INSIGHT tab page to 05-pages.css
- Added centering text and bullet point CSS code for the posts under 04-components-3-content.css

Link to my fork of the Insight Stream Page: https://computer8543.github.io/mindset-dojo.github.io/insight/