### PR TITLE
refactor: energy language uplift

### DIFF
--- a/_data/sections/mission.yaml
+++ b/_data/sections/mission.yaml
@@ -26,7 +26,7 @@ sections:
         - "We awaken the evolution already moving through each of us."
   - type: list
     data:
-      label: "Energy Integrity"
+      label: "Energy Calibration"
       items:
         - id: "authorship"
           label: "Authorship generates flow"
@@ -47,7 +47,7 @@ sections:
   - type: authors
     data:
       leadership_flow:
-        label: "⛩️⚡ Energy Authors"
+        label: "⛩️⚡ Authors"
         limit: 16
   - type: ctas
     data:

--- a/_data/sections/program.yaml
+++ b/_data/sections/program.yaml
@@ -181,7 +181,7 @@ sections:
   - type: authors
     data:
       leadership_flow:
-        label: "⛩️💫 Mentor Circle"
+        label: "⛩️💫 Guides"
         designation_type: program
         limit: 16
   - type: ctas

--- a/_data/sections/project.yaml
+++ b/_data/sections/project.yaml
@@ -61,7 +61,7 @@ sections:
   - type: authors
     data:
       leadership_flow:
-        label: "⛩️💫 Cultivator Circle"
+        label: "⛩️💫 Cultivators"
         designation_type: project
         limit: 8
   - type: ctas


### PR DESCRIPTION
## 🧭 Summary
This update refines the dojo’s energetic language — shifting from **Energy Integrity** to **Energy Calibration** — and clarifies role names to emphasize accessibility, precision, and living practice.

---

## ✨ Changes & Benefits

### 🕊️ Mission
- **Rename “Energy Integrity” → “Energy Calibration”** — shifts from static virtue to ongoing, practice-based tuning of leadership energy.  
- **Simplify “⛩️⚡ Energy Authors” → “⛩️⚡ Authors”** — centers authorship as an accessible act, not a gated identity.

### 🌿 Community
- **“⛩️ Mentor Circle” → “⛩️ Guides”** — flattens hierarchy and invites broader peer guidance.  
- **“⛩️ Cultivator Circle” → “⛩️ Cultivators”** — clarifies contribution as an active role, not a closed cohort.

### 💫 Individual
- **Calibration language in principles** — frames growth as continuous micro-adjustments under pressure, improving real-time presence.  
- **Cleaner role labels (“Authors,” “Guides,” “Cultivators”)** — reduces jargon fatigue and increases confidence to step in and contribute.

---

✅ **Result:**  
The site language now better reflects the living, relational, and embodied nature of Mindset Dojo practice — precise enough for leadership training, fluid enough for community flow.