### PR TITLE
tbd

### DIFF
--- a/_data/sections/program.yaml
+++ b/_data/sections/program.yaml
@@ -3,6 +3,16 @@ mantra: "Don't Resist. Resonate."
 mantra_mark: "Resonate."
 description: "A layered training journey—presence, nervous-system skill, and conversational leadership applied in real contexts."
 sections:
+  - type: text
+    data:
+      label: "At the Threshold"
+      items:
+        - "Training begins with contact — not concept."
+        - "Orient to the field, where principles set the tone for practice."
+        - "Each level is a threshold, not a rank — a way of deepening presence."
+        - "Leadership designations steward the rhythm and keep the field alive."
+        - "Before entering Orientation, reach out to a Cultivator for context."
+        - "Human connection is the first threshold."
   - type: principles
     data:
       principles_title: "Core Principles"

--- a/_includes/sections/_dispatch.html
+++ b/_includes/sections/_dispatch.html
@@ -54,7 +54,7 @@ Each case delegates to a small, focused template for that section type.
     {% include sections/markdown.html section=section %}
 
   {%- when 'principles' -%}
-    {% include sections/principles.html section=section principles_title=principles_title page_data=site.data.sections.principles principles=principles principles_groups=principles_groups %}
+    {% include sections/principles.html section=section %}
 
   {%- when 'quote' -%}
     {% include sections/quote.html section=section %}

--- a/_includes/sections/collection-stream.html
+++ b/_includes/sections/collection-stream.html
@@ -5,6 +5,8 @@ Parameters:
   collection: collection name (include.collection or section.data.collection)
   filter_key: front-matter key to filter by (optional)
   filter_values: array or scalar of filter values (optional)
+  label: heading shown above the stream (optional; falls back to section data)
+  show_hr: render an <hr> above the section when true (default false)
   sort_by: key to sort by (include.sort_by or section.data.sort_by)
   reverse: boolean to reverse results (include.reverse or section.data.reverse)
   excerpt_length: passed to collection-item include
@@ -109,8 +111,12 @@ Parameters:
 {%- if content_md == nil and D and D.field -%}
   {%- assign content_md = page[D.field] -%}
 {%- endif -%}
+{%- assign show_hr = include.show_hr | default: section.data.show_hr | default: false -%}
 
 {%- if posts_count > 0 -%}
+  {%- if show_hr -%}
+    <hr>
+  {%- endif -%}
   {%- assign section_attrs = 'id="collection-stream" class="md-flow"' -%}
   {%- if initial_limit -%}
     {%- capture section_attrs -%}id="collection-stream" class="md-flow" data-collection-stream="toggle" data-initial-limit="{{ initial_limit }}"{%- endcapture -%}

--- a/_insights/2025/bill-westfall/2025-10-23-zen-and-insight.md
+++ b/_insights/2025/bill-westfall/2025-10-23-zen-and-insight.md
@@ -10,10 +10,6 @@ forms:
   - stillness-contemplation
   - revealed-preference-reflection
   - stance
-principles:
-  - relax
-  - center
-  - resonate
 excerpt: "Simple beginning Zen principles applied to larger spiritual insight."
 ---
 

--- a/_insights/2025/bill-westfall/2025-10-25-shakespeare-and-metaphor.md
+++ b/_insights/2025/bill-westfall/2025-10-25-shakespeare-and-metaphor.md
@@ -8,10 +8,6 @@ authors:
   - bill-westfall
 forms:
   - stillness-contemplation
-principles:
-  - relax
-  - meet
-  - resonate
 excerpt: "The use of metaphor in Zen and Shakespeare and how they both bring value."
 ---
 

--- a/_insights/2025/bill-westfall/2025-10-30-complaint-and-help.md
+++ b/_insights/2025/bill-westfall/2025-10-30-complaint-and-help.md
@@ -9,11 +9,6 @@ authors:
 forms:
   - stillness-contemplation
   - stance
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: "Reflection on the 'Don't Train, Complain...?' Mindset Dojo insight."
 ---
 

--- a/_insights/2025/bill-westfall/2025-11-05-terror-or-reverence.md
+++ b/_insights/2025/bill-westfall/2025-11-05-terror-or-reverence.md
@@ -11,11 +11,6 @@ forms:
   - dojo
   - integration-under-fire
   - stance
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: "Reflection on the 'Dojo' Mindset form."
 ---
 

--- a/_insights/2025/bill-westfall/2025-11-08-trust-and-peitho.md
+++ b/_insights/2025/bill-westfall/2025-11-08-trust-and-peitho.md
@@ -9,11 +9,6 @@ authors:
 forms:
   - stillness-contemplation
   - circle
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: "Reflection on 'trust' in the 'Circle' Mindset form."
 ---
 

--- a/_insights/2025/kyle-ingersoll/2025-07-26-blue-belt-reflection.md
+++ b/_insights/2025/kyle-ingersoll/2025-07-26-blue-belt-reflection.md
@@ -10,11 +10,6 @@ forms:
   - integration-under-fire
   - threshold
   - stance
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 published_date: 2025-07-26
 refactored_date: 2025-11-07
 excerpt: "Through Blue Belt training, I learned that Fearless Leadership begins not with control, but with the awareness to lead, follow, and act through balance."

--- a/_insights/2025/kyle-ingersoll/2025-08-23-build-owe-wait-win.md
+++ b/_insights/2025/kyle-ingersoll/2025-08-23-build-owe-wait-win.md
@@ -9,9 +9,6 @@ forms:
   - integration-under-fire
   - sensei
   - stance
-principles:
-  - relax
-  - center
 published_date: 2025-08-23
 refactored_date: 2025-11-07
 excerpt: "A reflection on the MetaShift from Visionary to Organizer energy, where doing nothing—*for now*—becomes the wisest move."

--- a/_insights/2025/kyle-ingersoll/2025-09-08-not-knowing.md
+++ b/_insights/2025/kyle-ingersoll/2025-09-08-not-knowing.md
@@ -11,11 +11,6 @@ forms:
   - mat
   - revealed-preference-reflection
   - stance
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 published_date: 2025-09-08
 refactored_date: 2025-11-07
 excerpt: "A reflection on how the Mat Sessions and community practice of Mindset Dojo helped me transform ego-driven self-improvement into humble, fearless growth through beginner’s mind."

--- a/_insights/2025/kyle-ingersoll/2025-09-17-breath-of-stance.md
+++ b/_insights/2025/kyle-ingersoll/2025-09-17-breath-of-stance.md
@@ -9,11 +9,6 @@ forms:
   - integration-under-fire
   - revealed-preference-reflection
   - stance
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 published_date: 2025-09-17
 refactored_date: 2025-11-07
 excerpt: "When tension hardens between mismatched energies, Stances offer a way to realign through breath, tone, and presence—shifting both yourself and the field of conversation."

--- a/_insights/2025/kyle-ingersoll/2025-09-19-fable-on-opposition.md
+++ b/_insights/2025/kyle-ingersoll/2025-09-19-fable-on-opposition.md
@@ -10,11 +10,6 @@ forms:
   - threshold
   - stance
   - martial-attitude
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 published_date: 2025-09-19
 refactored_date: 2025-11-07
 excerpt: "Opposition is not just resistance — it is the sharpening edge that deepens our roots, clarifies our direction, and prepares us to rise beyond limits."

--- a/_insights/2025/kyle-ingersoll/2025-09-22-map-of-consciousness.md
+++ b/_insights/2025/kyle-ingersoll/2025-09-22-map-of-consciousness.md
@@ -11,11 +11,6 @@ forms:
   - three-question-reflection
   - threshold
   - stance
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 published_date: 2025-09-22
 refactored_date: 2025-11-07
 excerpt: "When life punches first, the Map of Consciousness helps us notice where we stand — below the line in contraction or above it in creation — and trains us to shift through breath, tone, and awareness."

--- a/_insights/2025/kyle-ingersoll/2025-09-22-tone.md
+++ b/_insights/2025/kyle-ingersoll/2025-09-22-tone.md
@@ -8,10 +8,6 @@ forms:
   - three-question-reflection
   - revealed-preference-reflection
   - stance
-principles:
-  - relax
-  - center
-  - resonate
 published_date: 2025-09-22
 refactored_date: 2025-11-07
 excerpt: "Tone is the subliminal weather of a conversation — it quietly decides whether others open, build, or shut down."

--- a/_insights/2025/kyle-ingersoll/2025-09-23-way-of-paradox.md
+++ b/_insights/2025/kyle-ingersoll/2025-09-23-way-of-paradox.md
@@ -12,10 +12,6 @@ forms:
   - integration-under-fire
   - threshold
   - stance
-principles:
-  - relax
-  - center
-  - resonate
 excerpt: "Paradox is the hidden gate of leadership, where resistance dissolves and the small self expands into the boundless flow of Ki."
 ---
 

--- a/_insights/2025/kyle-ingersoll/2025-09-30-fear-as-teacher.md
+++ b/_insights/2025/kyle-ingersoll/2025-09-30-fear-as-teacher.md
@@ -14,11 +14,6 @@ forms:
   - threshold
   - revealed-preference-reflection
   - stance
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: "How fear becomes a teacher and what its shadow reveals about presence and response."
 ---
 

--- a/_insights/2025/kyle-ingersoll/2025-10-07-ethical-technologist-ki-manifesto.md
+++ b/_insights/2025/kyle-ingersoll/2025-10-07-ethical-technologist-ki-manifesto.md
@@ -12,11 +12,6 @@ forms:
   - revealed-preference-reflection
   - stance
   - martial-attitude
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: "When the coder becomes the cultivator — ethics ceases to be rule-following and becomes resonance itself."
 ---
 

--- a/_insights/2025/kyle-ingersoll/2025-10-15-force-for-peace.md
+++ b/_insights/2025/kyle-ingersoll/2025-10-15-force-for-peace.md
@@ -12,11 +12,6 @@ forms:
   - revealed-preference-reflection
   - stance
   - martial-attitude
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: "When resonance fails and words no longer reach, the true martial art is to wield even one’s shadow with clarity — using force not to conquer, but to protect the peace that presence built."
 ---
 

--- a/_insights/2025/kyle-ingersoll/2025-10-16-human-guide-ai-follow.md
+++ b/_insights/2025/kyle-ingersoll/2025-10-16-human-guide-ai-follow.md
@@ -13,10 +13,6 @@ forms:
   - threshold
   - revealed-preference-reflection
   - stance
-principles:
-  - relax
-  - center
-  - resonate
 excerpt: "When code becomes debt, only human guidance can teach AI the Way forward."
 ---
 

--- a/_insights/2025/kyle-ingersoll/2025-10-18-way-of-plus-ki.md
+++ b/_insights/2025/kyle-ingersoll/2025-10-18-way-of-plus-ki.md
@@ -10,9 +10,6 @@ forms:
   - dojo
   - sensei
   - stance
-principles:
-  - relax
-  - resonate
 excerpt: "When the mind empties, body and universe become one — this is Plus Ki."
 ---
 

--- a/_insights/2025/kyle-ingersoll/2025-10-22-gift-that-wants-something-back.md
+++ b/_insights/2025/kyle-ingersoll/2025-10-22-gift-that-wants-something-back.md
@@ -12,11 +12,6 @@ forms:
   - threshold
   - revealed-preference-reflection
   - stance
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: "Giving without awareness creates imbalance; giving with awareness turns donation into resonance, where both giver and world are enriched."
 ---
 

--- a/_insights/2025/kyle-ingersoll/2025-10-26-circle-teaching-learning.md
+++ b/_insights/2025/kyle-ingersoll/2025-10-26-circle-teaching-learning.md
@@ -20,11 +20,6 @@ forms:
   - stance
   - martial-attitude
   - zazen
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: "At ZLOTC, I discovered that every act of teaching is also an act of learning — when we reflect, allow, and connect, Ki extends, and the circle becomes a spiral."
 ---
 

--- a/_insights/2025/kyle-ingersoll/2025-10-27-mind-ki-form.md
+++ b/_insights/2025/kyle-ingersoll/2025-10-27-mind-ki-form.md
@@ -11,11 +11,6 @@ forms:
   - sensei
   - dojo
   - stance
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: "When mind without Ki meets Ki given form, structure and spirit find each other — and even silence begins to move."
 ---
 

--- a/_insights/2025/kyle-ingersoll/2025-11-01-conflict-becomes-dojo.md
+++ b/_insights/2025/kyle-ingersoll/2025-11-01-conflict-becomes-dojo.md
@@ -14,11 +14,6 @@ forms:
   - revealed-preference-reflection
   - stance
   - martial-attitude
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: | 
   When two people meet in conflict with the intention to learn rather than win, tension becomes the dojo where relationship, awareness, and leadership are forged.
 ---

--- a/_insights/2025/kyle-ingersoll/2025-11-08-martial-attitude-continuous-awareness-continuous-deployment.md
+++ b/_insights/2025/kyle-ingersoll/2025-11-08-martial-attitude-continuous-awareness-continuous-deployment.md
@@ -14,11 +14,6 @@ forms:
   - stance
   - martial-attitude
   - threshold
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: "Martial Attitude is not opposition but attunement — the clarity to meet force with harmony, transforming conflict into coherence."
 ---
 

--- a/_insights/2025/michael-basil/2025-08-03-houston-attitude.md
+++ b/_insights/2025/michael-basil/2025-08-03-houston-attitude.md
@@ -11,11 +11,6 @@ forms:
   - sensei
   - stance
   - martial-attitude
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 published_date: 2025-08-03
 refactored_date: 2025-11-07
 excerpt: "When tone shifts, awareness follows—revealing the MetaShift from control to connection that transforms every conversation into practice."

--- a/_insights/2025/michael-basil/2025-10-06-unlearning-hierarchy.md
+++ b/_insights/2025/michael-basil/2025-10-06-unlearning-hierarchy.md
@@ -15,11 +15,6 @@ forms:
   - threshold
   - stance
   - martial-attitude
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: "In the Dojo, leadership is cultivation, not control. Circles replace chains of command. Authorship replaces ownership."
 ---
 

--- a/_insights/2025/michael-basil/2025-10-08-conversation-as-code.md
+++ b/_insights/2025/michael-basil/2025-10-08-conversation-as-code.md
@@ -12,11 +12,6 @@ forms:
   - threshold
   - revealed-preference-reflection
   - stance
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: "Every conversation writes code into the field — tone, timing, and language compile into patterns that shape what becomes possible next."
 ---
 

--- a/_insights/2025/michael-basil/2025-10-09-cultivating-a-threshold-based-authorship-network.md
+++ b/_insights/2025/michael-basil/2025-10-09-cultivating-a-threshold-based-authorship-network.md
@@ -11,10 +11,6 @@ forms:
   - dojo
   - threshold
   - stance
-principles:
-  - center
-  - meet
-  - resonate
 excerpt: "In the dojo, we’re not trying to build an audience — we’re cultivating a field of thresholds: experiences that transform presence into trust."
 ---
 

--- a/_insights/2025/michael-basil/2025-10-09-spiraling-with-the-shadow-in-star-wars.md
+++ b/_insights/2025/michael-basil/2025-10-09-spiraling-with-the-shadow-in-star-wars.md
@@ -10,9 +10,6 @@ forms:
   - integration-under-fire
   - threshold
   - stance
-principles:
-  - center
-  - meet
 excerpt: "When we turn toward the shadow — fear, anger, ambition, loss — and bring it into awareness, the circle becomes a spiral."
 ---
 

--- a/_insights/2025/michael-basil/2025-10-12-technology-of-self-authorship.md
+++ b/_insights/2025/michael-basil/2025-10-12-technology-of-self-authorship.md
@@ -11,11 +11,6 @@ forms:
   - integration-under-fire
   - threshold
   - stance
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: "In Mindset Dojo, we integrate presence through language — weaving body, breath, system, and story into a living practice of awareness and authorship."
 ---
 

--- a/_insights/2025/michael-basil/2025-10-13-from-explorer-to-cultivator.md
+++ b/_insights/2025/michael-basil/2025-10-13-from-explorer-to-cultivator.md
@@ -10,9 +10,6 @@ forms:
   - dojo
   - threshold
   - stance
-principles:
-  - center
-  - resonate
 excerpt: "In Mindset Dojo, every pull request tests a threshold — transforming exploration into cultivation, and curiosity into coherence."
 ---
 

--- a/_insights/2025/michael-basil/2025-10-16-feedback-as-fields.md
+++ b/_insights/2025/michael-basil/2025-10-16-feedback-as-fields.md
@@ -15,9 +15,6 @@ forms:
   - revealed-preference-reflection
   - stance
   - martial-attitude
-principles:
-  - center
-  - resonate
 excerpt: "As Mindset Dojo moves from late-alpha toward beta, feedback becomes our training ground — a way to find balance, alignment, and presence in motion."
 ---
 

--- a/_insights/2025/michael-basil/2025-10-18-when-everything-is-a-risk.md
+++ b/_insights/2025/michael-basil/2025-10-18-when-everything-is-a-risk.md
@@ -12,11 +12,6 @@ forms:
   - revealed-preference-reflection
   - stance
   - martial-attitude
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: "When guarantees fade and change becomes constant, presence becomes the most reliable investment."
 ---
 

--- a/_insights/2025/michael-basil/2025-10-20-dont-train-complain.md
+++ b/_insights/2025/michael-basil/2025-10-20-dont-train-complain.md
@@ -13,11 +13,6 @@ forms:
   - revealed-preference-reflection
   - stance
   - martial-attitude
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: "Every practitioner begins with a complaint — it’s the first mirror of the dojo. This piece opens the gate: an orientation to frustration, Self-learning, and the quiet art of turning noise into clarity."
 ---
 

--- a/_insights/2025/michael-basil/2025-10-23-demonstration-becomes-dojo.md
+++ b/_insights/2025/michael-basil/2025-10-23-demonstration-becomes-dojo.md
@@ -13,11 +13,6 @@ forms:
   - threshold
   - stance
   - zazen
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: "A reflection on our recent MetaShift Community Demonstration with Zen Leader — Off the Cushion, where the wisdom of the crowd helped clarify our signature form: Integration Under Fire."
 ---
 

--- a/_insights/2025/michael-basil/2025-10-24-attention-portfolio-intelligence.md
+++ b/_insights/2025/michael-basil/2025-10-24-attention-portfolio-intelligence.md
@@ -12,11 +12,6 @@ forms:
   - revealed-preference-reflection
   - stance
   - martial-attitude
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: |
   Every living system runs on one scarce resource: attention. How we train it determines what grows, what withers, and what evolves. 
   This piece explores how Lean, Agile, and finance principles converge in the art of managing the attention portfolio — and how awareness itself becomes alpha.

--- a/_insights/2025/michael-basil/2025-10-25-immunity-from-emotional-exploitation.md
+++ b/_insights/2025/michael-basil/2025-10-25-immunity-from-emotional-exploitation.md
@@ -15,11 +15,6 @@ forms:
   - revealed-preference-reflection
   - stance
   - martial-attitude
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: |
   How do you stay open and connected when emotions turn manipulative? This reflection explores the
   practice of moving through the field without absorbing it — cultivating clarity, compassion, and

--- a/_insights/2025/michael-basil/2025-10-26-self-evolution-is-socially-annoying.md
+++ b/_insights/2025/michael-basil/2025-10-26-self-evolution-is-socially-annoying.md
@@ -16,11 +16,6 @@ forms:
   - revealed-preference-reflection
   - stance
   - martial-attitude
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: >
   Evolution can feel like magic from the inside and disruption from the outside. 
   When awareness deepens, social gravity shifts—and both the person changing and 

--- a/_insights/2025/michael-basil/2025-10-27-self-evolution-of-emotional-extraction.md
+++ b/_insights/2025/michael-basil/2025-10-27-self-evolution-of-emotional-extraction.md
@@ -16,11 +16,6 @@ forms:
   - revealed-preference-reflection
   - stance
   - martial-attitude
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: |
   When sympathy stops being care and becomes currency, the bond is ready to evolve.  
   This piece traces how emotional extraction refines into awareness—linking the arc from  

--- a/_insights/2025/michael-basil/2025-10-27-zero-sympathy-phasing.md
+++ b/_insights/2025/michael-basil/2025-10-27-zero-sympathy-phasing.md
@@ -16,11 +16,6 @@ forms:
   - revealed-preference-reflection
   - stance
   - martial-attitude
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: >
   Zero-sympathy phasing is not detachment but metabolization—the ability to stay
   fully connected to the emotional field without collapsing into rescue or control.

--- a/_insights/2025/michael-basil/2025-10-28-politics-of-attention.md
+++ b/_insights/2025/michael-basil/2025-10-28-politics-of-attention.md
@@ -15,11 +15,6 @@ forms:
   - revealed-preference-reflection
   - stance
   - martial-attitude
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: |
   Attention has become the most contested resource in modern life. 
   The way we give, guard, and negotiate it reveals how we relate—to ourselves, to others, and to the moment we're in.

--- a/_insights/2025/michael-basil/2025-10-30-continuous-reconciliation.md
+++ b/_insights/2025/michael-basil/2025-10-30-continuous-reconciliation.md
@@ -14,11 +14,6 @@ forms:
   - revealed-preference-reflection
   - stance
   - martial-attitude
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: |
   Networking is what happens when distance dissolves. When there’s no gap between intention and impact, signals flow and the system breathes. Whether in APIs or human conversations, networks are where awareness meets awareness.
 ---

--- a/_insights/2025/michael-basil/2025-11-03-art-of-the-first-ninety-seconds.md
+++ b/_insights/2025/michael-basil/2025-11-03-art-of-the-first-ninety-seconds.md
@@ -14,11 +14,6 @@ forms:
   - integration-under-fire
   - stance
   - martial-attitude
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: "A meta reflection on composing Driver, Organizer, Collaborator, and Visionary energies within the first ninety seconds to regulate trust."
 ---
 

--- a/_insights/2025/michael-basil/2025-11-03-fable-of-the-first-ninety-seconds.md
+++ b/_insights/2025/michael-basil/2025-11-03-fable-of-the-first-ninety-seconds.md
@@ -14,11 +14,6 @@ forms:
   - integration-under-fire
   - stance
   - martial-attitude
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: "During a timed council trial, a warrior moves through Driver, Organizer, Collaborator, and Visionary stances to create alignment within the first ninety seconds."
 ---
 

--- a/_insights/2025/michael-basil/2025-11-06-art-of-meeting-the-mind-where-stuck.md
+++ b/_insights/2025/michael-basil/2025-11-06-art-of-meeting-the-mind-where-stuck.md
@@ -15,11 +15,6 @@ forms:
   - threshold
   - stance
   - martial-attitude
-principles:
-  - relax
-  - center
-  - meet
-  - resonate
 excerpt: "Whenever attention is stuck—whether in frustration, overthinking, or burnout—the way forward isn’t to push harder. It’s to meet awareness where it’s holding on, and draw a threshold toward movement."
 ---
 

--- a/_layouts/form.html
+++ b/_layouts/form.html
@@ -4,7 +4,12 @@ layout: post
 
 {{ content }}
 
-<hr>
-<h2>Related Insights</h2>
-
-{% include sections/collection-stream.html section=section collection="insights" filter_key="forms" filter_values=page.slug post_display_limit=5 %}
+{% include sections/collection-stream.html
+  section=section
+  collection="insights"
+  filter_key="forms"
+  filter_values=page.slug
+  post_display_limit=5
+  label="Related Insights"
+  show_hr=true
+%}

--- a/_layouts/insight.html
+++ b/_layouts/insight.html
@@ -17,14 +17,6 @@ layout: post
 {% endfor %}
 
 
-{% if page.principles %}
-  {%- assign principles_groups = "" | split: "|" -%}
-  {%- assign principles_groups = principles_groups | push: "program" -%}
-  
-  {% include sections/principles.html section=section principles_title="Related Principles" page_data=site.data.sections.principles principles=page.principles principles_groups=principles_groups %}
-  <hr>
-{% endif %}
-
 {% if page.forms %}
   <h2>Related Forms</h2>
 

--- a/_layouts/insight.html
+++ b/_layouts/insight.html
@@ -18,7 +18,12 @@ layout: post
 
 
 {% if page.forms %}
-  <h2>Related Forms</h2>
-
-  {% include sections/collection-stream.html section=section collection="forms" filter_key="forms" filter_values=page.forms %}
+  {% include sections/collection-stream.html
+    section=section
+    collection="forms"
+    filter_key="forms"
+    filter_values=page.forms
+    label="Related Forms"
+    show_hr=true
+  %}
 {% endif %}


### PR DESCRIPTION
## **At the Threshold — Orientation Update & Template Fix**

### **Description of Changes**
- Added a new **“At the Threshold”** lead-in on the Program page to orient visitors before entering Orientation.  
- Clarified the relationship between **principles, training levels, leadership designations, and Cultivators**.  
- **Removed mapped principles** from individual Insight articles to simplify authoring and focus on form relations.  
- **Fixed a template dispatch bug** in the principles section to ensure proper rendering across pages.  

---

### **Benefits**

**Individual**  
Provides a clearer, calmer way to begin — reducing friction for new practitioners and simplifying contribution for Insight authors.  

**Community**  
Aligns language and rhythm across the dojo; reinforces the Cultivator’s role as guide and point of connection.  

**Mission**  
Improves coherence of the living dojo framework — embodying the principle that training begins with contact, not concept.
