### PR TITLE
refactor: user experience harmonization

### DIFF
--- a/_data/sections/mission.yaml
+++ b/_data/sections/mission.yaml
@@ -54,14 +54,14 @@ sections:
   - type: quote
     data:
       text: "In a fast-changing world, human connection is a superpower to train."
-  - type: authors
-    data:
-      leadership_flow:
-        label: "⛩️🌿 Self-Authors"
-        limit: 16
   - type: ctas
     data:
       items:
         - label: "Cross the Threshold"
           ref: program
+  - type: authors
+    data:
+      leadership_flow:
+        label: "⛩️🌿 Self-Authors"
+        limit: 16
 ...

--- a/_data/sections/program.yaml
+++ b/_data/sections/program.yaml
@@ -186,15 +186,15 @@ sections:
         - "Open gates for others."
         - "Always return to training."
         - "Grow the field."
+  - type: ctas
+    data:
+      items:
+        - label: "Cross Threshold Zero"
+          ref: connect
   - type: authors
     data:
       leadership_flow:
         label: "⛩️💫 Guides"
         designation_type: program
         limit: 16
-  - type: ctas
-    data:
-      items:
-        - label: "Cross Threshold Zero"
-          ref: connect
 ...

--- a/_data/sections/project.yaml
+++ b/_data/sections/project.yaml
@@ -50,15 +50,15 @@ sections:
         - "Become a Cultivator."
         - "Open pathways for others."
         - "Grow the field."
+  - type: ctas
+    data:
+      items:
+        - label: "Tend the Garden"
+          ref: repo
   - type: authors
     data:
       leadership_flow:
         label: "⛩️💫 Cultivators"
         designation_type: project
         limit: 8
-  - type: ctas
-    data:
-      items:
-        - label: "Tend the Garden"
-          ref: repo
 ...

--- a/_includes/sections/author.html
+++ b/_includes/sections/author.html
@@ -12,7 +12,7 @@ if called without an author object.
 
 {% assign author = include.item | default: include.author %}
 
-<section class="md-author-card">
+<section class="md-card md-author-card">
   {% assign author_slug = author.slug | to_s | strip | slugify %}
   {% assign author_name = author.name | default: "Author" %}
   {% assign profile_url = '/authors/' | append: author_slug | append: '/' | relative_url %}

--- a/_includes/sections/author.html
+++ b/_includes/sections/author.html
@@ -10,9 +10,11 @@ This file now guards the markup with `if include.author` so it won't error
 if called without an author object.
 {%- endcomment -%}
 
+{% assign author = include.item | default: include.author %}
+
 <section class="md-author-card">
-  {% assign author_slug = include.author.slug | to_s | strip | slugify %}
-  {% assign author_name = include.author.name | default: "Author" %}
+  {% assign author_slug = author.slug | to_s | strip | slugify %}
+  {% assign author_name = author.name | default: "Author" %}
   {% assign profile_url = '/authors/' | append: author_slug | append: '/' | relative_url %}
   {% assign avatar_path = '/media/author-avatar/' | append: author_slug | append: '.jpg' | relative_url %}
 
@@ -25,12 +27,12 @@ if called without an author object.
 
   <h2><a href="{{ profile_url }}">{{ author_name }}</a></h2>
 
-  {%- if include.author.emoji_signature -%}
-    <h3 class="author-card-emoji-signature"> {{ include.author.emoji_signature }} </h3>
+  {%- if author.emoji_signature -%}
+    <h3 class="author-card-emoji-signature"> {{ author.emoji_signature }} </h3>
   {%- endif -%}
 
-  {%- assign mantra_value = include.author.mantra | to_s | strip -%}
-  {%- assign mantra_mark_value = include.author.mantra_mark | to_s | strip -%}
+  {%- assign mantra_value = author.mantra | to_s | strip -%}
+  {%- assign mantra_mark_value = author.mantra_mark | to_s | strip -%}
   {%- assign has_mantra = mantra_value != "" and mantra_value != "null" -%}
   {%- assign has_mantra_mark = mantra_mark_value != "" and mantra_mark_value != "null" -%}
   {%- if has_mantra or has_mantra_mark -%}
@@ -54,7 +56,7 @@ if called without an author object.
     <p class="author-card-mantra">{{ mantra_rendered | strip }}</p>
   {%- endif -%}
 
-  {%- assign ld = include.author.leadership_designations -%}
+  {%- assign ld = author.leadership_designations -%}
   {%- if ld -%}
     {%- assign lines = "" | split: "" -%}
     {%- for item in ld -%}
@@ -68,10 +70,10 @@ if called without an author object.
     {%- endif -%}
   {%- endif -%}
 
-  {%- if include.author.program_level -%}
+  {%- if author.program_level -%}
     <div class="md-group">
-      {%- if include.author.program_level -%}
-        {% assign program_level = include.author.program_level | plus: 0 %}
+      {%- if author.program_level -%}
+        {% assign program_level = author.program_level | plus: 0 %}
         {% assign level = site.data.sections.program.sections | where: "type", "levels" | map: "data" | map: "items" | first | where: "level", program_level | first %}
         {% include icons/level.svg
           class="md-level-svg"

--- a/_includes/sections/card-grid.html
+++ b/_includes/sections/card-grid.html
@@ -5,9 +5,11 @@ Reusable card grid wrapper. Accepts:
   initial_limit: hide cards beyond this index (for Show All)
   total_count: size of the full list (defaults to items.size)
   wrapper_class: optional extra classes on the grid container
+  item: optional single item to render (when not providing an array)
 {%- endcomment -%}
 
-{%- assign items = include.items | default: "" -%}
+{%- assign items = include.items -%}
+{%- assign single_item = include.item -%}
 {%- assign item_partial = include.item_partial | default: "sections/collection-item.html" -%}
 {%- assign initial_limit = include.initial_limit | default: nil -%}
 {%- assign total_count = include.total_count | default: nil -%}
@@ -16,8 +18,14 @@ Reusable card grid wrapper. Accepts:
   {%- assign grid_class = grid_class | append: " " | append: include.wrapper_class -%}
 {%- endif -%}
 
-{%- assign items_array = items | array -%}
-{%- assign total_items = total_count | default: items_array | size -%}
+{%- assign items_array = nil -%}
+{%- if single_item -%}
+  {%- assign items_array = "" | split:"|" | push: single_item -%}
+  {%- assign total_items = total_count | default: 1 -%}
+{%- else -%}
+  {%- assign items_array = items | array -%}
+  {%- assign total_items = total_count | default: items_array | size -%}
+{%- endif -%}
 
 {%- if total_items == 1 -%}
   {%- assign grid_class = grid_class | append: " card-grid-single" -%}
@@ -61,13 +69,13 @@ Reusable card grid wrapper. Accepts:
            data-tags="{{ filter_value }}">
         {%- case item_partial -%}
           {%- when "sections/form-card.html" -%}
-            {% include sections/form-card.html post=item %}
+            {% include sections/form-card.html item=item post=item %}
           {%- when "sections/author.html" -%}
-            {% include sections/author.html author=item %}
+            {% include sections/author.html item=item author=item %}
           {%- when "sections/level-card.html" -%}
-            {% include sections/level-card.html level=item %}
+            {% include sections/level-card.html item=item level=item %}
           {%- else -%}
-            {% include sections/collection-item.html post=item %}
+            {% include sections/collection-item.html item=item post=item %}
         {%- endcase -%}
       </div>
     {%- endfor -%}

--- a/_includes/sections/collection-item.html
+++ b/_includes/sections/collection-item.html
@@ -9,7 +9,7 @@ Notes:
   - honor hide_author so grouped-by-author lists can render an author card once
 {%- endcomment -%}
 
-{%- assign post = include.post -%}
+{%- assign post = include.item | default: include.post -%}
 {%- assign excerpt_len = include.excerpt_length | default: 220 -%}
 {%- assign hide_author = include.hide_author | default: false -%}
 

--- a/_includes/sections/form-card.html
+++ b/_includes/sections/form-card.html
@@ -7,7 +7,7 @@
   {%- assign desc_source = doc.card_excerpt | default: doc.excerpt | default: doc.summary | default: doc.description -%}
   {%- assign desc_html = desc_source | default: "" | markdownify -%}
   {%- assign desc_text = desc_html | strip_html | strip_newlines | truncate: 160 -%}
-  <article class="form-card">
+  <article class="md-card form-card">
     <div class="form-card-icon" aria-hidden="true">
       <i class="{{ icon_class }}"></i>
     </div>

--- a/_includes/sections/form-card.html
+++ b/_includes/sections/form-card.html
@@ -1,5 +1,4 @@
-{%- assign doc = include.post | default: post -%}
-{%- if doc -%}
+{%- assign doc = include.item | default: include.post -%}
   {%- assign form_title = doc.title | default: "Form" -%}
   {%- assign form_url = doc.url | relative_url -%}
   {%- assign raw_slug = doc.slug | default: doc.path | split: "/" | last | split: "." | first -%}
@@ -17,4 +16,3 @@
       <p>{{ desc_text }}</p>
     {%- endif -%}
   </article>
-{%- endif -%}

--- a/_includes/sections/level-card.html
+++ b/_includes/sections/level-card.html
@@ -1,5 +1,4 @@
-{%- assign level = include.level | default: include.item | default: item -%}
-{%- if level -%}
+{%- assign level = include.item | default: include.level -%}
   {%- assign flows = level.flows | default: "" -%}
   <article class="level-card">
     <div class="level-card-icon">
@@ -31,4 +30,3 @@
       </ul>
     {%- endif -%}
   </article>
-{%- endif -%}

--- a/_includes/sections/level-card.html
+++ b/_includes/sections/level-card.html
@@ -1,6 +1,6 @@
 {%- assign level = include.item | default: include.level -%}
   {%- assign flows = level.flows | default: "" -%}
-  <article class="level-card">
+  <article class="md-card level-card">
     <div class="level-card-icon">
       {% include icons/level.svg
         class="md-level-svg"

--- a/_layouts/form.html
+++ b/_layouts/form.html
@@ -2,10 +2,8 @@
 layout: post
 ---
 
-{%- assign form_items = "" | split:"|" -%}
-{%- assign form_items = form_items | push: page -%}
 {% include sections/card-grid.html
-  items=form_items
+  item=page
   total_count=1
   item_partial="sections/form-card.html" %}
 

--- a/_layouts/form.html
+++ b/_layouts/form.html
@@ -2,7 +2,12 @@
 layout: post
 ---
 
-{% include sections/form-card.html post=page %}
+{%- assign form_items = "" | split:"|" -%}
+{%- assign form_items = form_items | push: page -%}
+{% include sections/card-grid.html
+  items=form_items
+  total_count=1
+  item_partial="sections/form-card.html" %}
 
 {{ content }}
 

--- a/assets/css/03-layout.css
+++ b/assets/css/03-layout.css
@@ -1,4 +1,13 @@
 @layer layout {
+  :root {
+    --card-min: 260px;
+    --card-gap: 16px;
+    --card-grid-max: 720px;
+    --card-radius: 24px;
+    --card-padding: 16px;
+    --card-padding-compact: 12px;
+  }
+
   /* Global spacing for sections */
   section { margin-bottom: 20px; }
 
@@ -81,6 +90,64 @@
       grid-template-columns: 1fr;
       grid-gap: 24px;
     }
+  }
+
+  /* Shared card grid */
+  .card-stream-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(var(--card-min), 1fr));
+    gap: var(--card-gap);
+    width: 100%;
+    max-width: var(--card-grid-max);
+    margin: 24px auto 0;
+    justify-content: center;
+    justify-items: center;
+  }
+
+  .card-stream-item {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    min-width: var(--card-min);
+    max-width: var(--card-min);
+  }
+
+  .card-grid-single,
+  .card-grid-double {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--card-gap);
+    justify-content: center;
+    width: 100%;
+    margin: 24px auto 0;
+  }
+
+  .card-grid-single { max-width: var(--card-min); }
+
+  .card-grid-double { max-width: calc(var(--card-min) * 2 + var(--card-gap)); }
+
+  .card-grid-double .card-stream-item {
+    flex: 0 0 var(--card-min);
+    max-width: var(--card-min);
+  }
+
+  @media (width <= 560px) {
+    .card-stream-grid {
+      grid-template-columns: minmax(var(--card-min), 1fr);
+      max-width: 100%;
+    }
+  }
+
+  .card-stream-grid[data-visible-items="1"] {
+    display: flex;
+    justify-content: center;
+    max-width: 100%;
+  }
+
+  .card-stream-grid[data-visible-items="1"] .card-stream-item {
+    flex: 0 0 var(--card-min);
+    max-width: var(--card-min);
+    width: 100%;
   }
 
   /* FLOW section pattern */

--- a/assets/css/04-components-3-content.css
+++ b/assets/css/04-components-3-content.css
@@ -101,11 +101,6 @@
     max-width: 520px;
   }
 
-  .card-grid-single .card-stream-item,
-  .card-grid-levels .card-stream-item {
-    max-width: 280px;
-  }
-  
   .card-grid-double .card-stream-item {
     flex: 0 0 240px;
     max-width: 240px;
@@ -140,25 +135,6 @@
     flex: 0 0 240px;
     max-width: 240px;
     width: 100%;
-  }
-
-  .card-grid-levels.card-stream-grid[data-visible-items="1"] {
-    display: flex;
-    justify-content: center;
-    max-width: 100%;
-  }
-
-  .card-grid-levels.card-stream-grid[data-visible-items="1"] .card-stream-item {
-    flex: 0 0 280px;
-    max-width: 280px;
-    width: 100%;
-  }
-
-  @media (width <= 640px) {
-    .card-grid-levels.card-stream-grid {
-      grid-template-columns: minmax(0, 1fr);
-      max-width: 100%;
-    }
   }
 
   .level-card ul {
@@ -213,12 +189,6 @@
     font-style: italic;
     margin: 0;
   }
-
-  .card-grid-levels.card-stream-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    max-width: 640px;
-  }
-
 
   .card-grid-authors .md-author-card,
   .card-grid-levels .level-card {

--- a/assets/css/04-components-3-content.css
+++ b/assets/css/04-components-3-content.css
@@ -66,7 +66,7 @@
 
   .card-stream-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 240px));
+    grid-template-columns: repeat(2, minmax(260px, 1fr));
     gap: 16px;
     width: 100%;
     max-width: 720px;
@@ -79,7 +79,8 @@
     display: flex;
     flex-direction: column;
     width: 100%;
-    max-width: 240px;
+    min-width: 260px;
+    max-width: 260px;
   }
 
   .card-grid-single,
@@ -93,7 +94,7 @@
   }
 
   .card-grid-single {
-    max-width: 240px;
+    max-width: 260px;
   }
 
   .card-grid-double {
@@ -101,26 +102,14 @@
   }
 
   .card-grid-double .card-stream-item {
-    flex: 0 0 240px;
-    max-width: 240px;
+    flex: 0 0 260px;
+    max-width: 260px;
   }
 
-  @media (width >= 900px) {
+  @media (width <= 560px) {
     .card-stream-grid {
-      grid-template-columns: repeat(3, minmax(0, 240px));
-    }
-  }
-
-  @media (width <= 768px) {
-    .card-stream-grid {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+      grid-template-columns: minmax(260px, 1fr);
       max-width: 100%;
-    }
-  }
-
-  @media (width <= 520px) {
-    .card-stream-grid {
-      grid-template-columns: minmax(0, 1fr);
     }
   }
 
@@ -131,8 +120,8 @@
   }
 
   .card-stream-grid[data-visible-items="1"] .card-stream-item {
-    flex: 0 0 240px;
-    max-width: 240px;
+    flex: 0 0 260px;
+    max-width: 260px;
     width: 100%;
   }
 

--- a/assets/css/04-components-3-content.css
+++ b/assets/css/04-components-3-content.css
@@ -64,65 +64,19 @@
      Generic card streams
      ======================= */
 
-  .card-stream-grid {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(260px, 1fr));
-    gap: 16px;
-    width: 100%;
-    max-width: 720px;
-    margin: 24px auto 0;
-    justify-content: center;
-    justify-items: center;
-  }
-
-  .card-stream-item {
+  .md-card {
+    border: 2px solid var(--border-dark-color);
+    border-radius: var(--card-radius);
+    padding: var(--card-padding);
+    background-color: var(--card-bg, var(--dark-color-primary));
     display: flex;
     flex-direction: column;
+    gap: 12px;
+    text-align: center;
+    min-height: 100%;
+    height: 100%;
     width: 100%;
-    min-width: 260px;
-    max-width: 260px;
-  }
-
-  .card-grid-single,
-  .card-grid-double {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 16px;
-    justify-content: center;
-    width: 100%;
-    margin: 24px auto 0;
-  }
-
-  .card-grid-single {
-    max-width: 260px;
-  }
-
-  .card-grid-double {
-    max-width: 520px;
-  }
-
-  .card-grid-double .card-stream-item {
-    flex: 0 0 260px;
-    max-width: 260px;
-  }
-
-  @media (width <= 560px) {
-    .card-stream-grid {
-      grid-template-columns: minmax(260px, 1fr);
-      max-width: 100%;
-    }
-  }
-
-  .card-stream-grid[data-visible-items="1"] {
-    display: flex;
-    justify-content: center;
-    max-width: 100%;
-  }
-
-  .card-stream-grid[data-visible-items="1"] .card-stream-item {
-    flex: 0 0 260px;
-    max-width: 260px;
-    width: 100%;
+    margin: 0;
   }
 
   .level-card ul {
@@ -140,19 +94,7 @@
     text-align: center;
   }
 
-  .form-card {
-    border: 2px solid var(--border-dark-color);
-    border-radius: 24px;
-    padding: 12px;
-    width: 100%;
-    background-color: var(--dark-color-primary);
-    text-align: center;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    min-height: 100%;
-    height: 100%;
-  }
+  .form-card { padding: var(--card-padding-compact); }
 
   .form-card p {
     margin: 0;
@@ -179,20 +121,7 @@
   }
 
   .card-grid-authors .md-author-card,
-  .card-grid-levels .level-card {
-    border: 2px solid var(--border-dark-color);
-    border-radius: 24px;
-    padding: 16px;
-    background-color: var(--dark-color-primary);
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    text-align: center;
-    min-height: 100%;
-    height: 100%;
-    width: 100%;
-    margin: 0;
-  }
+  .card-grid-levels .level-card { text-align: center; }
 
   .card-grid-authors .md-author-card > p {
     margin: 0;


### PR DESCRIPTION
<https://basil-dojo.github.io>

## Summary of Changes

- **Section data harmonization**
  - Updated `mission.yaml`, `program.yaml`, and `project.yaml` so CTA blocks and author blocks follow a consistent order and structure across sections.
  - Ensures “Self-Authors / Guides / Cultivators” lists show up in a harmonized way after the primary CTAs.

- **Form layout refactor**
  - Updated `_layouts/form.html` to render forms through the shared `card-grid` include.
  - Single form pages now use the same centered card layout as other cards for a more consistent UX.

- **Card grid & responsiveness cleanup**
  - Simplified and normalized card sizing in `04-components-3-content.css` (unified max widths around 260px).
  - Refined grid behavior for different breakpoints and for `data-visible-items="1"` so single-card views stay centered and responsive.
  - Removed duplicated and conflicting grid rules to reduce layout quirks and improve maintainability.
