### PR TITLE
refactor: Self-authorship to Stance-Authorship

### DIFF
--- a/_data/sections/mission.yaml
+++ b/_data/sections/mission.yaml
@@ -2,55 +2,56 @@
 mantra: "Level Up."
 mantra_mark: "Level Up."
 description: |
-  Mindset Dojo is human-to-human live training for modern personal development,
-  communication, and leadership. In a world shaped by AI, rapid change, and
-  rising complexity, the ability to stay grounded, connect clearly, and
-  navigate relationships with confidence has become a critical human skill.
+  Mindset Dojo is live, human-to-human training for modern personal development,
+  communication, and leadership. In an era shaped by AI, rapid change, and rising
+  complexity, the ability to stay grounded, connect clearly, and navigate relationships
+  with confidence has become an essential human advantage.
 
-  Our training is delivered as simple, embodied mentorship practiced through
-  experiential sessions, practice labs, and real conversations. Each session
-  builds practical skills you can use immediately in work, relationships, and
-  everyday life. As you train your Self, your Network, and your World, you
-  begin to move through life with more clarity, presence, and authorship.
+  Our approach is simple and embodied: real mentorship, experiential practice labs,
+  and live conversations that strengthen presence, relational clarity, and emotional
+  intelligence. Each session builds practical skills you can apply immediately — in work,
+  relationships, and everyday life.
+
+  As you train, your stance stabilizes — and your presence, agency, and influence grow with it.
 sections:
   - type: text
     data:
       label: "Your Self"
       items:
         - "Build presence, emotional stability, and inner clarity under pressure."
-        - "Shift your energetic patterns and recover your center in real time."
-        - "Develop Self-Authorship — the ability to lead your inner world."
+        - "Shift your patterns and return to center in real time."
+        - "Strengthen your inner leadership and the agency to choose your stance."
   - type: text
     data:
       label: "Your Network"
       items:
         - "Strengthen the relational skill that shapes every conversation."
-        - "Communicate with more ease, honesty, and natural authority."
-        - "Transform reactive patterns into generative, collaborative ones."
+        - "Communicate with ease, honesty, and grounded authority."
+        - "Transform reactive patterns into collaborative, generative ones."
   - type: text
     data:
       label: "Your World"
       items:
-        - "Learn to influence culture through steady presence and behavior."
+        - "Influence culture through steady presence and consistent behavior."
         - "Create environments where clarity and psychological safety grow."
-        - "Show up as a grounded, empowering force in your circles that matter."
+        - "Show up as a grounded, empowering force in the circles that matter."
   - type: quote
     data:
-      text: "Human skills can be trained like martial arts — one level at a time."
+      text: "The stance you train becomes the presence you carry."
   - type: text
     data:
       label: "The Experience"
       items:
-        - "Human-to-human live mentorship — experiential, simple, and embodied."
+        - "Live human-to-human mentorship: experiential, simple, and embodied."
         - "Guided through practice labs, real conversations, and real interactions."
         - "Playful forms that build rhythm, awareness, and confidence with each rep."
   - type: text
     data:
       label: "The Transformation"
       items:
-        - "Less reactivity, more clarity — especially in hard moments."
-        - "Stronger relationships built on presence, honesty, and connection."
-        - "A more grounded inner compass that improves how you lead and live."
+        - "Less reactivity, more clarity — especially in challenging moments."
+        - "Stronger relationships grounded in presence, honesty, and connection."
+        - "A clearer inner compass that elevates how you lead, decide, and live."
   - type: quote
     data:
       text: "In a fast-changing world, human connection is a superpower to train."
@@ -62,6 +63,6 @@ sections:
   - type: authors
     data:
       leadership_flow:
-        label: "⛩️🌿 Self-Authors"
+        label: "⛩️🌿 Stance-Authors"
         limit: 16
 ...

--- a/_data/sections/mission.yaml
+++ b/_data/sections/mission.yaml
@@ -20,7 +20,7 @@ sections:
       items:
         - "Build presence, emotional stability, and inner clarity under pressure."
         - "Shift your patterns and return to center in real time."
-        - "Strengthen your inner leadership and the agency to choose your stance."
+        - "Strengthen your inner leadership and your agency to choose stance."
   - type: text
     data:
       label: "Your Network"
@@ -44,7 +44,7 @@ sections:
       items:
         - "Live human-to-human mentorship: experiential, simple, and embodied."
         - "Guided through practice labs, real conversations, and real interactions."
-        - "Playful forms that build rhythm, awareness, and confidence with each rep."
+        - "Playful forms that build rhythm, awareness, and confidence each rep."
   - type: text
     data:
       label: "The Transformation"

--- a/_forms/high-presence-networking.md
+++ b/_forms/high-presence-networking.md
@@ -65,7 +65,7 @@ This is the fieldwork of dojo presence — where awareness meets community in re
     - Ask:  
         - *What energy did I bring?*  
         - *What energy did I receive?*  
-    - Capture insights for your next Self-Authorship [Circle](../circle/) or [Mat](../mat/) session.
+    - Capture insights for your next Authorship [Circle](../circle/) or [Mat](../mat/) session.
 
 1. **Return and Refine**  
   Each encounter is an opportunity to test your training under real social pressure. The more you bring presence into the field, the more the field reflects coherence back to you.

--- a/_forms/level-up-transition.md
+++ b/_forms/level-up-transition.md
@@ -33,13 +33,13 @@ Transitions often feel subtle at first — a new steadiness, a softening of old 
 
 Form based practice may seem repetitive at times, but repetition brings shape. It reveals patterns that carried you through the previous phase, and it shows where gaps and edges still remain — in presence, in coherence, or in embodiment.
 
-A transition becomes visible when you notice yourself moving differently: how you listen, how you speak, how you recover, how you sense the field. These are the markers of the shift.
+A transition becomes visible when you notice yourself moving differently: how you listen, how you speak, how you recover, how you sense the field — and how your stance begins to author your responses rather than your conditioning.
 
 As you notice these shifts, pay attention to how the four principles may be emerging in your practice — sometimes faintly, sometimes unmistakably.
 
 ## Implementation
 
-Connect with others in this phase — not as a requirement, but as a practice.
+Connect with others in this phase — not as a requirement, but as a practice in shared awareness and stance.
 
 - Reach out to peers and reflect together on how each of you has changed.  
 - Engage a [Senpai](../senpai/) or [Sensei](../sensei/) for a conversation to sense what is emerging in you.  
@@ -47,14 +47,14 @@ Connect with others in this phase — not as a requirement, but as a practice.
 - Bring awareness to the [Thresholds](../threshold/) you have crossed in this level: what you carried in, what transformed, and what remains unresolved.  
 - Sense into the gaps and edges you are aware of now that you couldn’t see before.
 
-As part of implementation, revisit the four principles to sense how they are beginning to take shape in this phase of training. There is no expectation of mastery — simply awareness.
+As part of implementation, revisit the four principles to sense how they are taking shape in your nervous system and behavior during this phase. There is no expectation of mastery — simply awareness.
 
 - **Relax Completely** — Where did softening or releasing tension give you more room to move or choose?  
 - **Center with Intention** — When did you return to center instead of reacting? What helped?  
 - **Meet Fear with Presence** — What fears surfaced in this level? How did you relate to them?  
-- **Resonate Playfully** — Where did ease, humor, or creative flow return as tension cleared?
+- **Stance is Ki** — When did you author your stance instead of slipping into old conditioning? What shifted when your presence—not your pattern—set the tone?
 
-Revisit these questions each time you cross a level. Over time, you’ll sense a clear arc in how these principles show up.
+Revisit these questions each time you cross a level. Over time, your stance, presence, and patterns will reveal a clear arc.
 
 ### Reflective Harvest
 

--- a/_forms/meta.md
+++ b/_forms/meta.md
@@ -40,7 +40,7 @@ At first, it feels like a quiet observer watching practice unfold — the sense 
 
 Train the other forms. Train them sincerely, repeatedly, and with curiosity. Meta cannot be summoned by will; it develops through embodied integration.  
 
-Each form — from [Stance](../stance/) to [Circle](../circle/), from [Stillness Contemplation](../stillness-contemplation/) to [Three-Question Reflection](../three-question-reflection/) — provides conditions for Meta to emerge. As your Self-authorship grows, awareness begins to widen. Sometimes Meta shows up as insight after a difficult exchange, sometimes as intuition mid-conversation, sometimes as silence that steadies the field.  
+Each form — from [Stance](../stance/) to [Circle](../circle/), from [Stillness Contemplation](../stillness-contemplation/) to [Three-Question Reflection](../three-question-reflection/) — provides conditions for Meta to emerge. As you train Stance-authorship, awareness begins to widen. Sometimes Meta shows up as insight after a difficult exchange, sometimes as intuition mid-conversation, sometimes as silence that steadies the field.  
 
 Acknowledge it. Let it participate. Allow it to mature without grasping for control. Informed by [Martial Attitude](../martial-attitude/), Meta learns the deeper rhythm of right timing — when awareness must move decisively, and when stillness itself is the most skillful move.
 

--- a/_forms/resonate.md
+++ b/_forms/resonate.md
@@ -36,7 +36,7 @@ The book illuminates how resonance moves through mind, body, and voice; how fear
 - Relax completely
 - Center with intention  
 - Meet fear with presence  
-- Playful resonance is Ki  
+- Stance is Ki  
 
 Read slowly. Let the ideas land in your nervous system, not just your intellect. Every insight is an invitation to practice.
 

--- a/_forms/resonate.md
+++ b/_forms/resonate.md
@@ -63,6 +63,6 @@ As you work through the book:
    - Which pattern or form calls for deeper integration?  
    - How will I carry this awareness into my next conversation or practice?  
 
-5. **Integration.** Bring your reflections to Self-Authorship [Circle](../circle/) and [Mat](../mat/) practice as appropriate. Share what’s alive for you; teach through example.  
+5. **Integration.** Bring your reflections to Authorship [Circle](../circle/) and [Mat](../mat/) practice as appropriate. Share what’s alive for you; teach through example.  
 
 Reading *Resonate* is a bridge between insight and embodiment — a way to align theory, energy, and presence through disciplined curiosity.

--- a/_insights/2025/michael-basil/2025.11.22-the-evening-of-the-seeded-stance.md
+++ b/_insights/2025/michael-basil/2025.11.22-the-evening-of-the-seeded-stance.md
@@ -1,0 +1,142 @@
+---
+layout: insight
+title: "The Evening of the Seeded Stance"
+title_mark: Seeded Stance
+published_date: 2025-11-22
+refactored_date: 2025-11-22
+authors:
+  - michael-basil
+forms:
+  - tone
+  - stance
+  - collaborator
+excerpt: >
+  A quiet evening fable about nervous-system connection, stance-shifting,
+  and the moment a new form of agency is seeded.
+---
+
+It was evening on the hill,  
+and the two lanterns sat on the porch where they had weathered so many seasons.
+
+That night, the first lantern’s flame wasn’t flickering.  
+It wasn’t dim.  
+It was simply out.  
+A quiet, exhausted out.
+
+The second lantern saw this,  
+and instead of trying to explain why it wasn’t really out  
+or why it shouldn’t be out  
+or how to get the flame back —
+
+she **recognized the difficulty.**  
+Not as a failure.  
+As a truth.
+
+She sat beside him.  
+No distance.  
+No narrative.  
+No management.
+
+And with a calm center —  
+hara steady, breath grounded —  
+she looked directly into his eyes and said:
+
+**“This is a hard moment.  
+My mantra is:  
+I can do hard things.”**
+
+She didn’t rush.  
+She didn’t push.  
+She simply held the connection  
+and then gently invited:
+
+**“…you say it.”**
+
+Something in the air shifted.
+
+Not in thought —  
+in the nervous system.
+
+For the first time that evening,  
+the first lantern felt a flicker—not a flame,  
+but the unmistakable warmth of *being met.*
+
+The collaborator circuit came online.  
+Not through analysis.  
+Not through strategy.  
+Through direct connection.
+
+Heart to heart.  
+Hara to hara.  
+Presence to presence.
+
+In that connection,  
+Driver woke just enough to feel the truth of it.  
+Visionary sensed possibility.  
+Organizer relaxed its grip.  
+And the first lantern smiled —  
+a small, involuntary smile.
+
+Because he knew.
+
+He knew this wasn’t about positivity  
+or denial  
+or turning difficulty into something else.
+
+He knew this was stance.
+
+A stance that didn’t pretend the situation wasn’t hard —  
+but also didn’t collapse under it.
+
+So he said it.
+
+Quietly.  
+Honestly.  
+From center instead of story:
+
+**“I can do hard things.”**
+
+The moment was brief,  
+but it was real.
+
+And that was enough.
+
+A new stance was seeded in the body —  
+not fully grown,  
+not yet practiced,  
+but planted.
+
+Afterward, they sat together in the evening air.  
+Not fixing anything.  
+Not rewriting the past.  
+Not negotiating meaning.
+
+Just letting the body **digest the stance** that had been formed.
+
+And that digestion —  
+the quiet metabolizing —  
+is what shaped the next day.
+
+Because what grows from a stance  
+is not dramatic,  
+not sudden,  
+not loud.
+
+It echoes.
+
+Echoes in micro-decisions.  
+Echoes in which conversations open  
+and which ones stay closed.  
+Echoes in which paths feel possible  
+and which no longer do.  
+Echoes in what the nervous system can hold  
+and what it no longer needs to defend.
+
+Difficulty didn’t disappear.  
+But it was no longer insurmountable.
+
+Because the stance had changed.
+
+And once the stance changes,  
+everything that grows from it  
+changes, too.

--- a/_insights/2025/michael-basil/2025.11.22-the-evening-of-the-seeded-stance.md
+++ b/_insights/2025/michael-basil/2025.11.22-the-evening-of-the-seeded-stance.md
@@ -48,9 +48,7 @@ I can do hard things.”**
 She didn’t rush.  
 She didn’t push.  
 She simply held the connection  
-and then gently invited:
-
-**“…you say it.”**
+and then gently invited: **“…you say it.”**
 
 Something in the air shifted.
 
@@ -92,9 +90,7 @@ So he said it.
 
 Quietly.  
 Honestly.  
-From center instead of story:
-
-**“I can do hard things.”**
+From center instead of story: **“I can do hard things.”**
 
 The moment was brief,  
 but it was real.


### PR DESCRIPTION
## Pull Request Summary: Copy Refinement and Alignment With Stance-Focused Language

### Summary of Changes
This change set updates the landing-page copy to reflect the refined Mindset Dojo framework centered on **stance, presence, and agency**. Key updates include:

- A rewritten description section emphasizing embodied training over conceptual self-authorship.
- Clearer, more accessible phrasing across “Your Self,” “Your Network,” and “Your World.”
- Updated pull quotes aligned with the new narrative arc, including:  
  **“The stance you train becomes the presence you carry.”**
- Streamlined wording for greater clarity, rhythm, and SEO friendliness.
- Removal of jargon and overly conceptual language in favor of grounded, somatic phrasing.

### Impact on the Mission
The updated language expresses the Dojo’s mission with greater clarity and precision. It better conveys our focus on training stance as the foundation of presence, agency, and influence, strengthening the narrative of Mindset Dojo as a modern, embodied leadership practice.

### Impact on the Community
These changes make the Dojo’s framework easier to understand and resonate with. Community members can more readily see how training unfolds and how different circuits—relational, emotional, somatic—come online through practice. The copy now reflects what participants actually experience.

### Impact on the Individual Experience
Visitors can more easily recognize the personal benefits of the training: recovering center under pressure, strengthening presence, improving communication, and making choices from agency rather than conditioning. The updated copy supports clearer onboarding and a more accurate first-contact impression of the work.

Overall, this refinement brings the site’s language into alignment with the Dojo’s evolving stance-based model, enhancing coherence and accessibility across the board.

<https://basil-dojo.github.io>
