### PR TITLE
Replace Contact and Project links with Support Page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,20 +40,20 @@ header_links:
     href: /forms/
   - label: AUTHORS
     href: /authors/
+  - label: SUPPORT
+    href: /support/
 
 footer_primary_links:
   - label: MISSION
     href: /
   - label: PROGRAM
     href: /program/
-  - label: PROJECT
-    href: https://github.com/mindset-dojo/mindset-dojo.github.io
   - label: FORMS
     href: /forms/
   - label: AUTHORS
     href: /authors/
-  - label: CONTACT
-    href: https://connect.mindset.dojo.center
+  - label: SUPPORT
+    href: /support/
 
 footer_secondary_links:
   - label: Privacy Policy

--- a/_config.yml
+++ b/_config.yml
@@ -40,8 +40,6 @@ header_links:
     href: /forms/
   - label: AUTHORS
     href: /authors/
-  - label: SUPPORT
-    href: /support/
 
 footer_primary_links:
   - label: MISSION

--- a/_data/sections/support.yaml
+++ b/_data/sections/support.yaml
@@ -20,7 +20,7 @@ sections:
         - "<a href=\"https://1000.contribute.mindset.dojo.center/\" target=\"_blank\" rel=\"noopener\">$1000 Forge Builder</a>"
   - type: text
     data:
-      label: "Stay Connected"
+      label: "Connection Channels"
       items:
         - "Email: <a href=\"mailto:sensei@dojo.center\">sensei@dojo.center</a>"
         - "Video: <a href=\"https://connect.mindset.dojo.center\">Connect</a>"

--- a/_data/sections/support.yaml
+++ b/_data/sections/support.yaml
@@ -4,7 +4,7 @@ mantra_mark: "Support."
 description: |
   Support Mindset Dojo by fueling an open-source training ground for
   AI integrated mindset, tactical, and leadership skill. These
-  contributions keep energy flowing so more can train, document, and publish their practice.
+  contributions keep energy flowing so more can train and publish their practice.
 sections:
   - type: markdown
     data:
@@ -22,8 +22,8 @@ sections:
     data:
       label: "Stay Connected"
       items:
-        - "Email Sensei: <a href=\"mailto:sensei@dojo.center\">sensei@dojo.center</a>"
-        - "Video call: <a href=\"https://connect.mindset.dojo.center\">Connect</a>."
+        - "Email: <a href=\"mailto:sensei@dojo.center\">sensei@dojo.center</a>"
+        - "Video: <a href=\"https://connect.mindset.dojo.center\">Connect</a>"
   - type: text
     data:
       label: "Open-Source Momentum"

--- a/_data/sections/support.yaml
+++ b/_data/sections/support.yaml
@@ -1,0 +1,40 @@
+---
+mantra: "Don't Pause. Support."
+mantra_mark: "Support."
+description: |
+  Support Mindset Dojo by fueling an open-source training ground for
+  mindset, nervous-system skill, and leadership experiments. These
+  contributions keep hosting, contributor onboarding, and Sensei time
+  accessible so anyone can train, document, and publish their practice.
+sections:
+  - type: markdown
+    data:
+      field: description
+  - type: text
+    data:
+      label: "Contribution Pathways"
+      items:
+        - "<a href=\"https://50.contribute.mindset.dojo.center/\" target=\"_blank\" rel=\"noopener\">$50 Pulse Support</a> - make space for one new reflection log."
+        - "<a href=\"https://100.contribute.mindset.dojo.center/\" target=\"_blank\" rel=\"noopener\">$100 Dojo Fuel</a> - cover hosting plus transcription for a story."
+        - "<a href=\"https://250.contribute.mindset.dojo.center/\" target=\"_blank\" rel=\"noopener\">$250 Circle Boost</a> - fund facilitation for a community session."
+        - "<a href=\"https://500.contribute.mindset.dojo.center/\" target=\"_blank\" rel=\"noopener\">$500 Mat Catalyst</a> - underwrite a month of Sensei guidance."
+        - "<a href=\"https://1000.contribute.mindset.dojo.center/\" target=\"_blank\" rel=\"noopener\">$1000 Forge Builder</a> - sponsor a new experiment or tooling sprint."
+  - type: text
+    data:
+      label: "Stay Connected"
+      items:
+        - "Email Sensei Michael: <a href=\"mailto:michael@basil.one\">michael@basil.one</a>"
+        - "Live video support happens through <a href=\"https://connect.mindset.dojo.center\">Connect</a>. Bring your current edge."
+  - type: text
+    data:
+      label: "Open-Source Momentum"
+      items:
+        - "<a href=\"https://github.com/mindset-dojo/mindset-dojo.github.io\" target=\"_blank\" rel=\"noopener\">GitHub Repo</a> - please star it so others find the project, then fork it when you're ready to contribute."
+  - type: ctas
+    data:
+      items:
+        - label: "Book a Live Support Call"
+          ref: connect
+        - label: "Star & Fork on GitHub"
+          url: https://github.com/mindset-dojo/mindset-dojo.github.io
+...

--- a/_data/sections/support.yaml
+++ b/_data/sections/support.yaml
@@ -3,9 +3,8 @@ mantra: "Don't Pause. Support."
 mantra_mark: "Support."
 description: |
   Support Mindset Dojo by fueling an open-source training ground for
-  mindset, nervous-system skill, and leadership experiments. These
-  contributions keep hosting, contributor onboarding, and Sensei time
-  accessible so anyone can train, document, and publish their practice.
+  AI integrated mindset, tactical, and leadership skill. These
+  contributions keep energy flowing so more can train, document, and publish their practice.
 sections:
   - type: markdown
     data:
@@ -14,17 +13,17 @@ sections:
     data:
       label: "Contribution Pathways"
       items:
-        - "<a href=\"https://50.contribute.mindset.dojo.center/\" target=\"_blank\" rel=\"noopener\">$50 Pulse Support</a> - make space for one new reflection log."
-        - "<a href=\"https://100.contribute.mindset.dojo.center/\" target=\"_blank\" rel=\"noopener\">$100 Dojo Fuel</a> - cover hosting plus transcription for a story."
-        - "<a href=\"https://250.contribute.mindset.dojo.center/\" target=\"_blank\" rel=\"noopener\">$250 Circle Boost</a> - fund facilitation for a community session."
-        - "<a href=\"https://500.contribute.mindset.dojo.center/\" target=\"_blank\" rel=\"noopener\">$500 Mat Catalyst</a> - underwrite a month of Sensei guidance."
-        - "<a href=\"https://1000.contribute.mindset.dojo.center/\" target=\"_blank\" rel=\"noopener\">$1000 Forge Builder</a> - sponsor a new experiment or tooling sprint."
+        - "<a href=\"https://50.contribute.mindset.dojo.center/\" target=\"_blank\" rel=\"noopener\">$50 Pulse Support</a>"
+        - "<a href=\"https://100.contribute.mindset.dojo.center/\" target=\"_blank\" rel=\"noopener\">$100 Dojo Fuel</a>"
+        - "<a href=\"https://250.contribute.mindset.dojo.center/\" target=\"_blank\" rel=\"noopener\">$250 Circle Boost</a>"
+        - "<a href=\"https://500.contribute.mindset.dojo.center/\" target=\"_blank\" rel=\"noopener\">$500 Mat Catalyst</a>"
+        - "<a href=\"https://1000.contribute.mindset.dojo.center/\" target=\"_blank\" rel=\"noopener\">$1000 Forge Builder</a>"
   - type: text
     data:
       label: "Stay Connected"
       items:
-        - "Email Sensei Michael: <a href=\"mailto:michael@basil.one\">michael@basil.one</a>"
-        - "Live video support happens through <a href=\"https://connect.mindset.dojo.center\">Connect</a>. Bring your current edge."
+        - "Email Sensei: <a href=\"mailto:sensei@dojo.center\">sensei@dojo.center</a>"
+        - "Video call: <a href=\"https://connect.mindset.dojo.center\">Connect</a>."
   - type: text
     data:
       label: "Open-Source Momentum"
@@ -33,7 +32,7 @@ sections:
   - type: ctas
     data:
       items:
-        - label: "Book a Live Support Call"
+        - label: "Schedule Conversation"
           ref: connect
         - label: "Star & Fork on GitHub"
           url: https://github.com/mindset-dojo/mindset-dojo.github.io

--- a/_data/sections/support.yaml
+++ b/_data/sections/support.yaml
@@ -1,5 +1,5 @@
 ---
-mantra: "Don't Pause. Support."
+mantra: "Don't Hesitate. Support."
 mantra_mark: "Support."
 description: |
   Support Mindset Dojo by fueling an open-source training ground for

--- a/support.md
+++ b/support.md
@@ -1,0 +1,6 @@
+---
+layout: threshold
+permalink: /support/
+css_id: support
+sections_key: support
+---


### PR DESCRIPTION
**Benefits:** 

- **Mission:** Spreads open source reflection by drawing the threshold
- **Community:**  Makes all the means of supporting and being supported by the community all on one convenient page
- **Individual:** Allows for connection with real people

[Support Page](https://computer8543.github.io/mindset-dojo.github.io/support/)